### PR TITLE
[TAO-0000][Bugfix] clip: fix retrieval AUC label alignment

### DIFF
--- a/nvidia_tao_pytorch/multimodal/clip/model/evaluation/retrieval.py
+++ b/nvidia_tao_pytorch/multimodal/clip/model/evaluation/retrieval.py
@@ -218,7 +218,7 @@ class RetrievalEvaluator:
                 ndcg_scores[k].append(compute_ndcg(sorted_labels, k))
 
             if self._compute_auc:
-                auc_scores.append(compute_auc(sims, sorted_labels))
+                auc_scores.append(compute_auc(sims[sorted_idx], sorted_labels))
 
         return RetrievalMetrics(
             recall_at_k={k: np.mean(v) for k, v in recall_scores.items() if v},

--- a/tests/multimodal_unit_test/clip/test_retrieval_metrics.py
+++ b/tests/multimodal_unit_test/clip/test_retrieval_metrics.py
@@ -199,6 +199,37 @@ class TestRetrievalEvaluatorGPU:
 
 
 @pytest.mark.multimodal_unit
+class TestRetrievalAUCAlignment:
+    """AUC needs scores and labels in the same order, not merely in range.
+
+    ``compute_auc`` sorts its ``scores`` argument internally and indexes
+    ``labels`` with the result, so passing gallery-order scores alongside
+    rank-order labels pairs each score with the wrong item relevance. The
+    existing ``0.0 <= auc <= 1.0`` assertions cannot catch that, because an
+    inverted value is still in range.
+    """
+
+    def setup_method(self):
+        """Build a query whose ranking order differs from gallery order."""
+        self.gallery = np.eye(4, dtype=np.float32)
+        # sims proportional to [1, 2, 3, 4] -> ranking order [3, 2, 1, 0].
+        self.query = np.array([[1, 2, 3, 4]], dtype=np.float32)
+        self.evaluator = RetrievalEvaluator(
+            k_values=(1,), compute_auc=True, device="cpu"
+        )
+
+    def test_only_lowest_scoring_item_relevant_is_auc_zero(self):
+        """The sole relevant item ranks last, so AUC is 0."""
+        metrics = self.evaluator.evaluate(self.query, self.gallery, [[0]])
+        assert abs(metrics.auc - 0.0) < 1e-6
+
+    def test_only_highest_scoring_item_relevant_is_auc_one(self):
+        """The sole relevant item ranks first, so AUC is 1."""
+        metrics = self.evaluator.evaluate(self.query, self.gallery, [[3]])
+        assert abs(metrics.auc - 1.0) < 1e-6
+
+
+@pytest.mark.multimodal_unit
 class TestRetrievalEvaluator:
     """Tests for RetrievalEvaluator."""
 


### PR DESCRIPTION
### What

`compute_auc` sorts its `scores` argument internally and then indexes `labels` with the result:

```python
sorted_idx = np.argsort(scores)
sorted_labels = labels[sorted_idx]
```

so the two arguments must be **index-aligned**. `retrieval.py:221` passed gallery-order `sims` together with rank-order `sorted_labels`, pairing each score with the relevance of a different item.

```diff
-                auc_scores.append(compute_auc(sims, sorted_labels))
+                auc_scores.append(compute_auc(sims[sorted_idx], sorted_labels))
```

### Why it matters

The reported AUC was **inverted**, not merely noisy:

| case | truth | before | after |
|---|---|---|---|
| only lowest-scoring item relevant | 0.0 | **1.0** | 0.0 |
| only highest-scoring item relevant | 1.0 | **0.0** | 1.0 |

### Why existing tests missed it

- `TestComputeAUC` exercises `compute_auc()` directly with already-aligned inputs, so it never sees the mismatch.
- `TestRetrievalEvaluatorGPU::test_auc_computed_by_default` asserts only `0.0 <= metrics.auc <= 1.0` — an inverted value satisfies that.

`TestRetrievalAUCAlignment` uses a query whose ranking order (`[3,2,1,0]`) differs from gallery order; with an identity-ordered fixture the two orderings coincide and the bug hides. Verified as a real discriminator: it fails on the old line and passes on the fixed one, while the other 26 tests in the file pass either way (28 passed with fix / 2 failed 26 passed without).

### Scope

Found while addressing @vpraveen-nv review feedback on [tao-deploy#36](https://github.com/NVIDIA-TAO/tao-deploy/pull/36), where the same one-line defect was flagged. It exists in three copies of this evaluator; the other two are fixed in tao-deploy#36 and tao-pytorch#94. This module is outside both PRs and already on `main`, so it gets its own change rather than widening a feature PR.