### PR TITLE
[TAO-0000][Bugfix] Log aggregate PAS validation metrics

### DIFF
--- a/nvidia_tao_pytorch/multimodal/clip/model/pl_clip_model.py
+++ b/nvidia_tao_pytorch/multimodal/clip/model/pl_clip_model.py
@@ -196,10 +196,10 @@ def _broadcast_pas_metrics(
     weighted_rows,
     device: torch.device,
 ) -> dict:
-    """Broadcast query-weighted PAS mAP/query counts from rank zero."""
+    """Broadcast query-weighted PAS metrics/query counts from rank zero."""
     collective_device = _collective_device(device)
     payload = torch.full(
-        (len(PAS_METADATA_QUERY_TYPES), 2),
+        (len(PAS_METADATA_QUERY_TYPES), 4),
         float("nan"),
         dtype=torch.float64,
         device=collective_device,
@@ -212,14 +212,18 @@ def _broadcast_pas_metrics(
             row = by_query_type.get(query_type)
             if row is not None:
                 payload[index, 0] = float(row["mAP"])
-                payload[index, 1] = float(row["num_queries"])
+                payload[index, 1] = float(row["Rank-1"])
+                payload[index, 2] = float(row["Rank-5"])
+                payload[index, 3] = float(row["num_queries"])
     if _distributed_ready():
         dist.broadcast(payload, src=0)
     payload = payload.cpu()
     return {
         query_type: {
             "mAP": float(payload[index, 0]),
-            "num_queries": int(payload[index, 1]),
+            "rank1": float(payload[index, 1]),
+            "rank5": float(payload[index, 2]),
+            "num_queries": int(payload[index, 3]),
         }
         for index, query_type in enumerate(PAS_METADATA_QUERY_TYPES)
         if not torch.isnan(payload[index, 0])
@@ -894,38 +898,45 @@ class CLIPPlModel(TAOLightningModule):
         return _broadcast_pas_metrics(weighted_rows, self.device)
 
     def _log_pas_metrics(self, metrics: dict, prefix: str) -> None:
-        """Log per-difficulty and overall query-weighted PAS mAP."""
-        overall_weighted_sum = 0.0
+        """Log per-difficulty and overall query-weighted PAS metrics."""
+        metric_names = ("mAP", "rank1", "rank5")
+        overall_weighted_sums = dict.fromkeys(metric_names, 0.0)
         overall_num_queries = 0
         for query_type in PAS_METADATA_QUERY_TYPES:
             query_metrics = metrics.get(query_type)
             if query_metrics is None:
                 continue
-            name = f"{prefix}/pas/{query_type}_mAP"
-            map_score = query_metrics["mAP"]
             num_queries = query_metrics["num_queries"]
-            self.log(name, map_score, sync_dist=True)
-            self.status_logging_dict[name] = str(map_score)
-            overall_weighted_sum += map_score * num_queries
+            for metric_name in metric_names:
+                name = f"{prefix}/pas/{query_type}_{metric_name}"
+                metric_value = query_metrics[metric_name]
+                self.log(name, metric_value, sync_dist=True)
+                self.status_logging_dict[name] = str(metric_value)
+                overall_weighted_sums[metric_name] += (
+                    metric_value * num_queries
+                )
+                logging.info(
+                    "%s: %.6f (%s deduplicated queries)",
+                    name,
+                    metric_value,
+                    f"{num_queries:,}",
+                )
             overall_num_queries += num_queries
-            logging.info(
-                "%s: %.6f (%s deduplicated queries)",
-                name,
-                map_score,
-                f"{num_queries:,}",
-            )
 
         if overall_num_queries:
-            name = f"{prefix}/pas/overall_mAP"
-            overall_map = overall_weighted_sum / overall_num_queries
-            self.log(name, overall_map, sync_dist=True)
-            self.status_logging_dict[name] = str(overall_map)
-            logging.info(
-                "%s: %.6f (%s deduplicated queries)",
-                name,
-                overall_map,
-                f"{overall_num_queries:,}",
-            )
+            for metric_name in metric_names:
+                name = f"{prefix}/pas/overall_{metric_name}"
+                metric_value = overall_weighted_sums[
+                    metric_name
+                ] / overall_num_queries
+                self.log(name, metric_value, sync_dist=True)
+                self.status_logging_dict[name] = str(metric_value)
+                logging.info(
+                    "%s: %.6f (%s deduplicated queries)",
+                    name,
+                    metric_value,
+                    f"{overall_num_queries:,}",
+                )
 
     def _evaluate_and_log_paired_retrieval(
         self,

--- a/nvidia_tao_pytorch/multimodal/clip/model/pl_clip_model.py
+++ b/nvidia_tao_pytorch/multimodal/clip/model/pl_clip_model.py
@@ -656,6 +656,13 @@ class CLIPPlModel(TAOLightningModule):
             "train/logit_scale", logit_scale.item(),
             on_step=True, on_epoch=False, prog_bar=False
         )
+        if outputs is not None and len(outputs) == 4:
+            logit_bias = outputs[3]
+            if logit_bias is not None:
+                self.log(
+                    "train/logit_bias", logit_bias.item(),
+                    on_step=True, on_epoch=False, prog_bar=False
+                )
         return loss_value
 
     def optimizer_step(self, *args, **kwargs):
@@ -887,20 +894,37 @@ class CLIPPlModel(TAOLightningModule):
         return _broadcast_pas_metrics(weighted_rows, self.device)
 
     def _log_pas_metrics(self, metrics: dict, prefix: str) -> None:
-        """Log query-weighted PAS mAP for easy, medium, and hard queries."""
+        """Log per-difficulty and overall query-weighted PAS mAP."""
+        overall_weighted_sum = 0.0
+        overall_num_queries = 0
         for query_type in PAS_METADATA_QUERY_TYPES:
             query_metrics = metrics.get(query_type)
             if query_metrics is None:
                 continue
             name = f"{prefix}/pas/{query_type}_mAP"
             map_score = query_metrics["mAP"]
+            num_queries = query_metrics["num_queries"]
             self.log(name, map_score, sync_dist=True)
             self.status_logging_dict[name] = str(map_score)
+            overall_weighted_sum += map_score * num_queries
+            overall_num_queries += num_queries
             logging.info(
                 "%s: %.6f (%s deduplicated queries)",
                 name,
                 map_score,
-                f"{query_metrics['num_queries']:,}",
+                f"{num_queries:,}",
+            )
+
+        if overall_num_queries:
+            name = f"{prefix}/pas/overall_mAP"
+            overall_map = overall_weighted_sum / overall_num_queries
+            self.log(name, overall_map, sync_dist=True)
+            self.status_logging_dict[name] = str(overall_map)
+            logging.info(
+                "%s: %.6f (%s deduplicated queries)",
+                name,
+                overall_map,
+                f"{overall_num_queries:,}",
             )
 
     def _evaluate_and_log_paired_retrieval(

--- a/tests/multimodal_unit_test/clip/test_pl_clip_model_validation.py
+++ b/tests/multimodal_unit_test/clip/test_pl_clip_model_validation.py
@@ -201,6 +201,8 @@ def _run_two_rank_pas_validation(rank, world_size, init_method):
         )
         assert set(metrics) == set(PAS_METADATA_QUERY_TYPES)
         assert all(value["mAP"] == 1.0 for value in metrics.values())
+        assert all(value["rank1"] == 1.0 for value in metrics.values())
+        assert all(value["rank5"] == 1.0 for value in metrics.values())
         assert all(value["num_queries"] == 2 for value in metrics.values())
     finally:
         dist.destroy_process_group()
@@ -295,32 +297,53 @@ class TestCLIPPASValidation:
 
         assert set(metrics) == set(PAS_METADATA_QUERY_TYPES)
         assert all(value["mAP"] == 1.0 for value in metrics.values())
+        assert all(value["rank1"] == 1.0 for value in metrics.values())
+        assert all(value["rank5"] == 1.0 for value in metrics.values())
         assert all(value["num_queries"] == 2 for value in metrics.values())
 
         model._log_pas_metrics(metrics, "val")
         assert [call[0][0] for call in model.logged] == [
             "val/pas/easy_mAP",
+            "val/pas/easy_rank1",
+            "val/pas/easy_rank5",
             "val/pas/medium_mAP",
+            "val/pas/medium_rank1",
+            "val/pas/medium_rank5",
             "val/pas/hard_mAP",
+            "val/pas/hard_rank1",
+            "val/pas/hard_rank5",
             "val/pas/overall_mAP",
+            "val/pas/overall_rank1",
+            "val/pas/overall_rank5",
         ]
 
-    def test_pas_overall_map_is_weighted_by_query_count(self):
-        """Overall PAS mAP represents every deduplicated query equally."""
+    def test_pas_overall_metrics_are_weighted_by_query_count(self):
+        """Overall PAS metrics represent every deduplicated query equally."""
         model = _validation_model(
             metadata_match_eval=True,
             evaluator=_CaptureEvaluator(),
         )
         metrics = {
-            "easy": {"mAP": 0.25, "num_queries": 4},
-            "medium": {"mAP": 0.5, "num_queries": 2},
-            "hard": {"mAP": 1.0, "num_queries": 1},
+            "easy": {
+                "mAP": 0.25, "rank1": 0.25, "rank5": 0.5,
+                "num_queries": 4,
+            },
+            "medium": {
+                "mAP": 0.5, "rank1": 0.5, "rank5": 0.75,
+                "num_queries": 2,
+            },
+            "hard": {
+                "mAP": 1.0, "rank1": 1.0, "rank5": 1.0,
+                "num_queries": 1,
+            },
         }
 
         model._log_pas_metrics(metrics, "val")
 
         logged = {call[0][0]: call[0][1] for call in model.logged}
         assert logged["val/pas/overall_mAP"] == pytest.approx(3 / 7)
+        assert logged["val/pas/overall_rank1"] == pytest.approx(3 / 7)
+        assert logged["val/pas/overall_rank5"] == pytest.approx(4.5 / 7)
         assert float(
             model.status_logging_dict["val/pas/overall_mAP"]
         ) == pytest.approx(3 / 7)

--- a/tests/multimodal_unit_test/clip/test_pl_clip_model_validation.py
+++ b/tests/multimodal_unit_test/clip/test_pl_clip_model_validation.py
@@ -302,7 +302,28 @@ class TestCLIPPASValidation:
             "val/pas/easy_mAP",
             "val/pas/medium_mAP",
             "val/pas/hard_mAP",
+            "val/pas/overall_mAP",
         ]
+
+    def test_pas_overall_map_is_weighted_by_query_count(self):
+        """Overall PAS mAP represents every deduplicated query equally."""
+        model = _validation_model(
+            metadata_match_eval=True,
+            evaluator=_CaptureEvaluator(),
+        )
+        metrics = {
+            "easy": {"mAP": 0.25, "num_queries": 4},
+            "medium": {"mAP": 0.5, "num_queries": 2},
+            "hard": {"mAP": 1.0, "num_queries": 1},
+        }
+
+        model._log_pas_metrics(metrics, "val")
+
+        logged = {call[0][0]: call[0][1] for call in model.logged}
+        assert logged["val/pas/overall_mAP"] == pytest.approx(3 / 7)
+        assert float(
+            model.status_logging_dict["val/pas/overall_mAP"]
+        ) == pytest.approx(3 / 7)
 
     def test_multiple_pas_pair_files_load_in_dataloader_order(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
### What changes are proposed in this pull request?

  This PR improves CLIP training and PAS validation observability:

  - Logs the optional CLIP logit bias as `train/logit_bias`.
  - Preserves PAS mAP, Rank-1, Rank-5, and query counts across distributed validation.
  - Logs per-difficulty PAS metrics:
    - `val/pas/easy_mAP`, `easy_rank1`, and `easy_rank5`
    - `val/pas/medium_mAP`, `medium_rank1`, and `medium_rank5`
    - `val/pas/hard_mAP`, `hard_rank1`, and `hard_rank5`
  - Logs query-weighted summary metrics:
    - `val/pas/overall_mAP`
    - `val/pas/overall_rank1`
    - `val/pas/overall_rank5`
  - Produces equivalent `test/pas/*` metrics during testing.
  - Extends distributed and single-rank PAS validation tests to cover the new metrics and query-weighted aggregation.

  The existing PAS CSV fields remain `Rank-1` and `Rank-5`. Existing paired-retrieval `R@1` and `R@5` metric names are unchanged.

### Why are the changes needed?

-   CLIP training previously exposed logit scale but not logit bias, making it difficult to monitor the complete learned logit calibration state in W&B.
-   PAS validation reported separate easy, medium, and hard mAP values but did not provide a single summary metric. It also computed Rank-1 and Rank-5 internally without exposing them through training-time logging.
-   The new overall metrics weight each difficulty result by its number of deduplicated queries. This gives every validation query equal influence and provides practical summary metrics for experiment comparison and best-checkpoint selection.


### Related issues

TAO-1796

### Does this PR introduce _any_ user-facing change?

 Yes.

  Previously, PAS validation logged:

  ```text
  val/pas/easy_mAP
  val/pas/medium_mAP
  val/pas/hard_mAP
```
  It now additionally logs:
```
  train/logit_bias

  val/pas/easy_rank1
  val/pas/easy_rank5
  val/pas/medium_rank1
  val/pas/medium_rank5
  val/pas/hard_rank1
  val/pas/hard_rank5

  val/pas/overall_mAP
  val/pas/overall_rank1
  val/pas/overall_rank5
```
  Equivalent metrics are logged with the test/pas/ prefix during testing.

  `train/logit_bias` is emitted only for models that provide an optional logit-bias value. Existing metric names and configurations remain unchanged, so no migration is required.


### How was this patch tested?

Focused calibration and PAS validation tests:

```
  CUDA_VISIBLE_DEVICES='' pytest -q \
    tests/multimodal_unit_test/clip/test_logit_calibration.py \
    tests/multimodal_unit_test/clip/test_pl_clip_model_validation.py
```

  Result:

  60 passed, 5 warnings

  The tests cover:

  - Single-rank PAS metric evaluation.
  - Two-rank Gloo gathering and metric broadcasting.
  - Per-difficulty mAP, Rank-1, and Rank-5 values.
  - Overall metrics weighted by unequal query counts.
  - Existing biased and biasless CLIP calibration contracts.

  The commit hooks also completed successfully:

```
  TruffleHog secret scan: Passed
  license header: Passed
  pylint: Passed
  pydocstyle: Passed
  flake8: Passed
  DCO sign-off check: Passed

```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)

### Release note

CLIP training now reports logit bias and per-difficulty and query-weighted overall PAS mAP, Rank-1, and Rank-5 metrics.

### Checklist

- [X] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [X] I have read the contributing guidelines
- [X] The code follows the project's style, and lint and format checks pass locally
- [X] I added or updated tests covering this change
- [X] All tests pass locally
- [X] I added or updated documentation (README, docstrings, docs pages, examples)
- [  ] I updated the version, changelog, or migration notes if this change requires it
- [  ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [X] No secrets, credentials, proprietary data, or customer data are included in this PR
- [X] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->
