### PR TITLE
[Bugfix] grounding_dino: guard mixed-precision training on SM 12.x Blackwell

### DIFF
--- a/nvidia_tao_pytorch/cv/grounding_dino/scripts/train.py
+++ b/nvidia_tao_pytorch/cv/grounding_dino/scripts/train.py
@@ -21,38 +21,62 @@ from nvidia_tao_pytorch.cv.grounding_dino.model.pl_gdino_model import GDINOPlMod
 from nvidia_tao_pytorch.cv.grounding_dino.model.utils import grounding_dino_parser, ptm_adapter
 
 
-def _assert_precision_supported_on_device(precision):
-    """Fail fast on mixed-precision training on SM 12.x (RTX PRO 6000 Blackwell and siblings).
+def _configure_gemm_workarounds_for_device(precision):
+    """Work around the cuBLASLt SM 12.x batched-GEMM defect (RTX PRO 6000 Blackwell and siblings).
 
-    cuBLASLt's ``nvjet_sm120_*_tmaAB_*`` TMA GEMM kernels make illegal memory accesses on
-    SM 12.x for the skinny-N half-precision strided-batched GEMMs this model issues
-    (text cross-attention and the vision-text fusion layer). The fault happens inside the
-    library, poisons the CUDA context, and surfaces as ``CUBLAS_STATUS_INTERNAL_ERROR``
-    followed by ``cudaErrorIllegalAddress`` -- typically several minutes into a run and with
-    a traceback that points at unrelated code, which is very hard to act on.
+    cuBLASLt's ``nvjet_sm120_*_tmaAB_*`` TMA GEMM kernels make illegal memory accesses on SM 12.x
+    for the skinny-N strided-batched GEMMs this model issues (text encoder / text cross-attention
+    and the vision-text fusion layer). The fault happens inside the library, poisons the CUDA
+    context, and surfaces as ``CUBLAS_STATUS_INTERNAL_ERROR`` followed by
+    ``cudaErrorIllegalAddress``, usually with a traceback pointing at unrelated code.
 
-    Both fp16 and bf16 are affected (bf16 fails ~35% of runs, fp16 more often); fp32 is clean.
-    The defect is below the framework, so there is no reliable model-side workaround -- two
-    distinct kernels in the family were observed via different call paths. Datacenter Blackwell
-    (SM 10.x) is unaffected and is not gated here.
+    One kernel in that family is selected per compute type, so the defect is not tied to a single
+    precision:
 
-    Remove this guard once the container ships a cuBLAS with the fix.
+    ==========  =============================================  ===========================
+    Precision   Faulting kernel                                cuBLASLt entry point
+    ==========  =============================================  ===========================
+    fp16        ``nvjet_sm120_hsh_mma_16x128x32_...``          ``cublasLtHSHMatmul``
+    bf16        ``nvjet_sm120_tst_mma_128x8x32_...``           ``cublasLtTSTMatmul``
+    fp32/TF32   ``nvjet_sm120_sss_tf32_mma_32x64x32_...``      ``cublasLtSSSMatmul``
+    ==========  =============================================  ===========================
+
+    The fp32 variant is only reachable because this container's PyTorch build enables TF32 matmul
+    by default, so plain fp32 training still lands on a tensor-core kernel. Turning TF32 off for
+    matmul routes fp32 onto an unaffected kernel and is enough to make fp32 training work; it does
+    not help fp16/bf16, whose kernels are selected by their own compute type, so those stay gated.
+
+    Datacenter Blackwell (SM 10.x) is unaffected and is not touched here. Remove all of this once
+    the container ships a cuBLAS with the fix.
     """
-    if precision == '32-true' or not torch.cuda.is_available():
+    if not torch.cuda.is_available():
         return
 
     props = torch.cuda.get_device_properties(0)
     if props.major != 12:
         return
 
-    raise RuntimeError(
-        f"Mixed-precision training (train.precision={precision}) is not supported on "
-        f"{props.name} (SM {props.major}{props.minor}). The cuBLAS shipped in this container has "
-        f"a defect in its SM 12.x batched-GEMM kernels that corrupts the CUDA context and crashes "
-        f"training with 'CUBLAS_STATUS_INTERNAL_ERROR' / 'illegal memory access'. "
-        f"Set 'train.precision: fp32' in your spec to train on this GPU "
-        f"(you may need to reduce dataset.batch_size to fit). ONNX export is unaffected."
-    )
+    if precision != '32-true':
+        raise RuntimeError(
+            f"Mixed-precision training (train.precision={precision}) is not supported on "
+            f"{props.name} (SM {props.major}{props.minor}). The cuBLAS shipped in this container "
+            f"has a defect in its SM 12.x batched-GEMM kernels that corrupts the CUDA context and "
+            f"crashes training with 'CUBLAS_STATUS_INTERNAL_ERROR' / 'illegal memory access'. "
+            f"Set 'train.precision: fp32' in your spec to train on this GPU "
+            f"(you may need to reduce dataset.batch_size to fit). ONNX export is unaffected."
+        )
+
+    # fp32 on its own is not sufficient: with TF32 matmul enabled (the default in this container)
+    # fp32 still dispatches to the faulting tensor-core kernel. Guarded so the log line is emitted
+    # once even though this runs both before and after the FSDP precision override.
+    if torch.backends.cuda.matmul.allow_tf32:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        logging.info(
+            "Disabling TF32 matmul on %s (SM %d%d): the cuBLAS in this container has a defect in "
+            "its SM 12.x TF32 batched-GEMM kernel that crashes training. This costs some "
+            "throughput and is removed once a fixed cuBLAS ships.",
+            props.name, props.major, props.minor
+        )
 
 
 def run_experiment(experiment_config):
@@ -69,7 +93,7 @@ def run_experiment(experiment_config):
 
     # Resolved up front so an unsupported precision fails before the model and dataloaders are
     # built, rather than minutes later.
-    _assert_precision_supported_on_device(precision)
+    _configure_gemm_workarounds_for_device(precision)
 
     resume_ckpt, trainer_kwargs = initialize_train_experiment(experiment_config)
 
@@ -146,7 +170,7 @@ def run_experiment(experiment_config):
 
     # Checked after the FSDP branch above, which overrides precision to 16-mixed regardless of
     # what the user configured -- so the guard has to see the precision actually handed to the Trainer.
-    _assert_precision_supported_on_device(precision)
+    _configure_gemm_workarounds_for_device(precision)
 
     trainer = Trainer(**trainer_kwargs,
                       num_nodes=num_nodes,

--- a/nvidia_tao_pytorch/cv/grounding_dino/scripts/train.py
+++ b/nvidia_tao_pytorch/cv/grounding_dino/scripts/train.py
@@ -5,6 +5,8 @@
 
 import os
 
+import torch
+
 from pytorch_lightning import Trainer
 
 from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
@@ -19,8 +21,56 @@ from nvidia_tao_pytorch.cv.grounding_dino.model.pl_gdino_model import GDINOPlMod
 from nvidia_tao_pytorch.cv.grounding_dino.model.utils import grounding_dino_parser, ptm_adapter
 
 
+def _assert_precision_supported_on_device(precision):
+    """Fail fast on mixed-precision training on SM 12.x (RTX PRO 6000 Blackwell and siblings).
+
+    cuBLASLt's ``nvjet_sm120_*_tmaAB_*`` TMA GEMM kernels make illegal memory accesses on
+    SM 12.x for the skinny-N half-precision strided-batched GEMMs this model issues
+    (text cross-attention and the vision-text fusion layer). The fault happens inside the
+    library, poisons the CUDA context, and surfaces as ``CUBLAS_STATUS_INTERNAL_ERROR``
+    followed by ``cudaErrorIllegalAddress`` -- typically several minutes into a run and with
+    a traceback that points at unrelated code, which is very hard to act on.
+
+    Both fp16 and bf16 are affected (bf16 fails ~35% of runs, fp16 more often); fp32 is clean.
+    The defect is below the framework, so there is no reliable model-side workaround -- two
+    distinct kernels in the family were observed via different call paths. Datacenter Blackwell
+    (SM 10.x) is unaffected and is not gated here.
+
+    Remove this guard once the container ships a cuBLAS with the fix.
+    """
+    if precision == '32-true' or not torch.cuda.is_available():
+        return
+
+    props = torch.cuda.get_device_properties(0)
+    if props.major != 12:
+        return
+
+    raise RuntimeError(
+        f"Mixed-precision training (train.precision={precision}) is not supported on "
+        f"{props.name} (SM {props.major}{props.minor}). The cuBLAS shipped in this container has "
+        f"a defect in its SM 12.x batched-GEMM kernels that corrupts the CUDA context and crashes "
+        f"training with 'CUBLAS_STATUS_INTERNAL_ERROR' / 'illegal memory access'. "
+        f"Set 'train.precision: fp32' in your spec to train on this GPU "
+        f"(you may need to reduce dataset.batch_size to fit). ONNX export is unaffected."
+    )
+
+
 def run_experiment(experiment_config):
     """Start the training."""
+    if experiment_config.train.precision.lower() == 'fp16':
+        precision = '16-mixed'
+    elif experiment_config.train.precision.lower() == 'bf16':
+        precision = 'bf16-mixed'
+    elif experiment_config.train.precision.lower() == 'fp32':
+        precision = '32-true'
+    else:
+        raise NotImplementedError(f"{experiment_config.train.precision} is not supported. \
+                                  Only bf16, fp16, and fp32 are supported")
+
+    # Resolved up front so an unsupported precision fails before the model and dataloaders are
+    # built, rather than minutes later.
+    _assert_precision_supported_on_device(precision)
+
     resume_ckpt, trainer_kwargs = initialize_train_experiment(experiment_config)
 
     dm = ODVGDataModule(experiment_config.dataset)
@@ -78,16 +128,6 @@ def run_experiment(experiment_config):
     is_dry_run = experiment_config.train.is_dry_run
     distributed_strategy = experiment_config.train.distributed_strategy
 
-    if experiment_config.train.precision.lower() == 'fp16':
-        precision = '16-mixed'
-    elif experiment_config.train.precision.lower() == 'bf16':
-        precision = 'bf16-mixed'
-    elif experiment_config.train.precision.lower() == 'fp32':
-        precision = '32-true'
-    else:
-        raise NotImplementedError(f"{experiment_config.train.precision} is not supported. \
-                                  Only bf16, fp16, and fp32 are supported")
-
     strategy = 'auto'
     if len(trainer_kwargs['devices']) > 1:
         # By default find_unused_parameters is set to False in Lightning
@@ -103,6 +143,10 @@ def run_experiment(experiment_config):
             precision = '16-mixed'
         else:
             raise NotImplementedError(f"{distributed_strategy} is not implemented. Only ddp and fsdp are supported")
+
+    # Checked after the FSDP branch above, which overrides precision to 16-mixed regardless of
+    # what the user configured -- so the guard has to see the precision actually handed to the Trainer.
+    _assert_precision_supported_on_device(precision)
 
     trainer = Trainer(**trainer_kwargs,
                       num_nodes=num_nodes,


### PR DESCRIPTION
## Problem

Grounding DINO training crashes nondeterministically on SM 12.x GPUs (RTX PRO 6000 Blackwell) whenever `train.precision` is `fp16` or `bf16`. Users see an opaque `CUBLAS_STATUS_INTERNAL_ERROR` followed by `cudaErrorIllegalAddress`, minutes into a run, with a traceback pointing at unrelated code (checkpoint saving, optimizer step).

## Root cause — below the framework

`compute-sanitizer memcheck` puts the illegal access **inside cuBLASLt's own kernels**:

```
Warp illegal address
    at nvjet_sm120_hsh_mma_16x128x32_10_16x32x32_tmaAB_bx_TNNN
    Host Frame: cublasLtHSHMatmul          [libcublasLt.so.13]
    Host Frame: cublasGemmStridedBatchedEx [libcublas.so.13]
    Host Frame: baddbmm_out_cuda_impl      [libtorch_cuda.so]
```

This is a **kernel family** issue, not one bad kernel. Three kernels have now been caught faulting — one per compute type, all TMA-based (`tmaAB`) skinny-N variants:

| Kernel | Entry | Precision | Reached via |
| --- | --- | --- | --- |
| `nvjet_sm120_hsh_mma_16x128x32_…_tmaAB_bx_TNNN` | `cublasLtHSHMatmul` | fp16 | `baddbmm` — `nn.MultiheadAttention` |
| `nvjet_sm120_tst_mma_128x8x32_…_tmaAB_bz_TNNN` | `cublasLtTSTMatmul` | bf16 | `bmm` — vision-text fusion layer |
| `nvjet_sm120_sss_**tf32**_mma_32x64x32_…_tmaAB_bz_TNNN` | `cublasLtSSSMatmul` | **fp32 via TF32** | `baddbmm` — text-encoder self-attention |

**The common factor is the TF32/TMA tensor-core kernels, not any one precision.** The fp32 variant is reachable because this container's PyTorch build ships `matmul.allow_tf32 = True` by default (`fp32_precision = tf32`), so ordinary fp32 training still lands on a tensor-core kernel. Shapes match what this model issues, e.g. `(16,900,32) @ (16,32,8)` for text cross-attention, where N is the text-token count.

## Evidence

Measured on the shipped images, idle GPU:

| Image / arch | fp32 | fp16 | bf16 |
| --- | --- | --- | --- |
| nightly `2026.8.16-rc-42`, RTX PRO 6000 (SM 120), N=20 | 20/20 pass* | — | **7/20 fail** |
| `7.1.0-rc-242`, RTX PRO 6000 (SM 120) | 3/3 pass* | 5/8 fail | 1/8 fail |
| A100 (SM 80), identical torch build | pass | pass | pass |

\* **These fp32 results are on synthetic unit-test data and are misleading.** On a real user
workload fp32 also crashes, in `cublasSgemmStridedBatched`; the synthetic shapes simply never
selected the faulting kernel. Do not read the fp32 column as "fp32 is safe".

Ruled out: missing sm_120 SASS (all TAO `.so` carry it), PTX JIT, MSDeformAttn custom kernels (fwd+bwd clean at real shapes), flash-attn/xformers, NCCL/multi-GPU (failure is single-GPU), and GPU memory pressure (fails 4/5 on a fully idle GPU).

## Why a guard rather than a code fix

No model-side workaround holds. Tested and rejected: disabling cuDNN/flash/mem-efficient SDPA backends, `preferred_blas_library("cublas")`, `CUBLASLT_WORKSPACE_SIZE=0`, `CUBLAS_WORKSPACE_CONFIG=:4096:8`, disabling reduced-precision reduction, and forcing `nn.MultiheadAttention` to fp32 (partial only). Routing MHA to SDPA via `need_weights=False` fixes the fp16 path (40/40) but not configs that fault via `torch.bmm` elsewhere — patching call sites just moves the failure.

So until the container ships a fixed cuBLAS, fail fast with an actionable message.

## Change

One file, `+78/−10`. `_configure_gemm_workarounds_for_device()` does two things on SM 12.x:

1. **Disables TF32 matmul** (`torch.backends.cuda.matmul.allow_tf32 = False`), which routes fp32
   onto an unaffected kernel. This is what actually makes fp32 training work — fp32 alone is not
   sufficient.
2. **Raises a clear `RuntimeError` for fp16/bf16**, whose kernels are chosen by their own compute
   type and are not helped by the TF32 switch.

- Precision resolution moved to the top of `run_experiment` so it fails in seconds, not after model + dataloader construction.
- Checked **again** after the FSDP branch, which overrides precision to `16-mixed` regardless of user config — otherwise fp32 + FSDP would silently re-enable the bug.
- Gated on `props.major == 12` only; datacenter Blackwell (SM 10.x) is unaffected and not gated. Guarded on `torch.cuda.is_available()` for CPU-only construction.

ONNX export is unaffected (it runs fp32 — verified 3/3 green on SM 120, including PyTorch↔ONNX parity) and is untouched.

## Test

Verified on real hardware with the module's real import path:

- **End-to-end on the reporting user's own data and spec**, RTX PRO 6000: before, the sanity-check
  validation died with `CUBLAS_STATUS_INTERNAL_ERROR` / illegal memory access. With this change
  validation completes — **mAP 0.5060 vs 0.5063** on their original bf16 run, i.e. numerically
  sound — and training proceeds past the step where it used to fail.
- RTX PRO 6000 (SM 120) unit check: `fp32` allowed with `allow_tf32` flipped to `False`;
  `bf16`/`fp16` blocked with the new message.
- A100 (SM 80): all three allowed, `allow_tf32` left untouched — no regression.
- `pylint --rcfile .pylintrc` 10.00/10; SPDX license-header hook passes.

No automated tests in this PR by design — the existing `grounding_dino` trainer tests are all `@pytest.mark.skip("flaky test to be fixed")`, and that flakiness needs its own investigation (it is at least partly *this* bug). Test coverage will follow separately.

## Follow-ups (not in this PR)

- File a cuBLAS bug for the `nvjet_sm120_*_tmaAB_*` family; remove this guard once a fixed cuBLAS ships.
- Un-skip / de-flake the `grounding_dino` test suite.
- Consider `need_weights=False` at the MHA call sites on its own merits (all sites discard the weights; it is faster and lower-memory).
- Add an SM 12.x board to the QA matrix.

