### PR TITLE
[TAO-1796][Bugfix] video_clip: avoid PyAV frame-thread deadlock

### DIFF
--- a/nvidia_tao_pytorch/multimodal/video_clip/dataloader/video_decode.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/dataloader/video_decode.py
@@ -196,7 +196,9 @@ def _load_with_pyav(video_path, num_frames, start_time_sec, end_time_sec,
 
     with av.open(str(video_path)) as container:
         stream = container.streams.video[0]
-        stream.thread_type = "AUTO"
+        # Frame threading can hang when sampled decoding exits before EOF;
+        # keep decoding parallel within each frame instead.
+        stream.thread_type = "SLICE"
         rate = _pyav_stream_rate(stream)
         actual_frames = _pyav_stream_length(stream, rate)
         if actual_frames <= 0:

--- a/nvidia_tao_pytorch/multimodal/video_clip/dataloader/video_decode.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/dataloader/video_decode.py
@@ -22,6 +22,7 @@ OpenCV, and logs which backend won.
 """
 
 import json
+import os
 
 import numpy as np
 from PIL import Image
@@ -196,6 +197,13 @@ def _load_with_pyav(video_path, num_frames, start_time_sec, end_time_sec,
 
     with av.open(str(video_path)) as container:
         stream = container.streams.video[0]
+        codec_context = stream.codec_context
+        if codec_context.codec.name == "h264_cuvid":
+            # torchrun exports LOCAL_RANK before DataLoader workers fork. Keep
+            # each rank's NVDEC work on its corresponding visible GPU instead
+            # of concentrating all 96 workers on device 0.
+            codec_context.options = dict(codec_context.options)
+            codec_context.options["gpu"] = os.environ.get("LOCAL_RANK", "0")
         # Frame threading can hang when sampled decoding exits before EOF;
         # keep decoding parallel within each frame instead.
         stream.thread_type = "SLICE"

--- a/nvidia_tao_pytorch/multimodal/video_clip/dataloader/video_decode.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/dataloader/video_decode.py
@@ -22,7 +22,6 @@ OpenCV, and logs which backend won.
 """
 
 import json
-import os
 
 import numpy as np
 from PIL import Image
@@ -197,13 +196,6 @@ def _load_with_pyav(video_path, num_frames, start_time_sec, end_time_sec,
 
     with av.open(str(video_path)) as container:
         stream = container.streams.video[0]
-        codec_context = stream.codec_context
-        if codec_context.codec.name == "h264_cuvid":
-            # torchrun exports LOCAL_RANK before DataLoader workers fork. Keep
-            # each rank's NVDEC work on its corresponding visible GPU instead
-            # of concentrating all 96 workers on device 0.
-            codec_context.options = dict(codec_context.options)
-            codec_context.options["gpu"] = os.environ.get("LOCAL_RANK", "0")
         # Frame threading can hang when sampled decoding exits before EOF;
         # keep decoding parallel within each frame instead.
         stream.thread_type = "SLICE"

--- a/tests/multimodal_unit_test/video_clip/test_video_text_loader.py
+++ b/tests/multimodal_unit_test/video_clip/test_video_text_loader.py
@@ -122,16 +122,8 @@ def fake_pyav(monkeypatch):
             for index in frame_indices
         }
 
-    class FakeCodec:
-        name = "h264_cuvid"
-
-    class FakeCodecContext:
-        codec = FakeCodec()
-        options = {}
-
     class FakeStream:
         thread_type = "AUTO"
-        codec_context = FakeCodecContext()
 
     stream = FakeStream()
 
@@ -311,10 +303,9 @@ class TestVideoTextDataset:
         ],
     )
     def test_pyav_requests_the_linspace_frame_indices(
-        self, fake_pyav, monkeypatch, num_frames, start_frame, end_frame, expected
+        self, fake_pyav, num_frames, start_frame, end_frame, expected
     ):
         """PyAV backend should decode exactly the sampled indices, in order."""
-        monkeypatch.setenv("LOCAL_RANK", "3")
         requested, stream = fake_pyav
         frames = video_decode._load_with_pyav(
             "/tmp/fake.mp4",
@@ -327,7 +318,6 @@ class TestVideoTextDataset:
 
         assert requested == [expected]
         assert stream.thread_type == "SLICE"
-        assert stream.codec_context.options == {"gpu": "3"}
         assert len(frames) == num_frames
         assert all(isinstance(frame, Image.Image) for frame in frames)
 

--- a/tests/multimodal_unit_test/video_clip/test_video_text_loader.py
+++ b/tests/multimodal_unit_test/video_clip/test_video_text_loader.py
@@ -122,8 +122,16 @@ def fake_pyav(monkeypatch):
             for index in frame_indices
         }
 
+    class FakeCodec:
+        name = "h264_cuvid"
+
+    class FakeCodecContext:
+        codec = FakeCodec()
+        options = {}
+
     class FakeStream:
         thread_type = "AUTO"
+        codec_context = FakeCodecContext()
 
     stream = FakeStream()
 
@@ -303,9 +311,10 @@ class TestVideoTextDataset:
         ],
     )
     def test_pyav_requests_the_linspace_frame_indices(
-        self, fake_pyav, num_frames, start_frame, end_frame, expected
+        self, fake_pyav, monkeypatch, num_frames, start_frame, end_frame, expected
     ):
         """PyAV backend should decode exactly the sampled indices, in order."""
+        monkeypatch.setenv("LOCAL_RANK", "3")
         requested, stream = fake_pyav
         frames = video_decode._load_with_pyav(
             "/tmp/fake.mp4",
@@ -318,6 +327,7 @@ class TestVideoTextDataset:
 
         assert requested == [expected]
         assert stream.thread_type == "SLICE"
+        assert stream.codec_context.options == {"gpu": "3"}
         assert len(frames) == num_frames
         assert all(isinstance(frame, Image.Image) for frame in frames)
 

--- a/tests/multimodal_unit_test/video_clip/test_video_text_loader.py
+++ b/tests/multimodal_unit_test/video_clip/test_video_text_loader.py
@@ -125,8 +125,10 @@ def fake_pyav(monkeypatch):
     class FakeStream:
         thread_type = "AUTO"
 
+    stream = FakeStream()
+
     class FakeContainer:
-        streams = SimpleNamespace(video=[FakeStream()])
+        streams = SimpleNamespace(video=[stream])
 
         def __enter__(self):
             return self
@@ -142,7 +144,7 @@ def fake_pyav(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "av", SimpleNamespace(open=lambda path: FakeContainer())
     )
-    return requested
+    return requested, stream
 
 
 @pytest.mark.multimodal_unit
@@ -304,6 +306,7 @@ class TestVideoTextDataset:
         self, fake_pyav, num_frames, start_frame, end_frame, expected
     ):
         """PyAV backend should decode exactly the sampled indices, in order."""
+        requested, stream = fake_pyav
         frames = video_decode._load_with_pyav(
             "/tmp/fake.mp4",
             num_frames=num_frames,
@@ -313,7 +316,8 @@ class TestVideoTextDataset:
             end_frame=end_frame,
         )
 
-        assert fake_pyav == [expected]
+        assert requested == [expected]
+        assert stream.thread_type == "SLICE"
         assert len(frames) == num_frames
         assert all(isinstance(frame, Image.Image) for frame in frames)
 


### PR DESCRIPTION
## What
Fix `video_clip` training stalls caused by PyAV frame threading during sampled decoding.

## Problem
`_load_with_pyav` used `thread_type = "AUTO"`, enabling frame threading even though sampled decoding exits before EOF. A blocked loader worker can starve its rank and eventually appear as an NCCL training hang.

## Solution
Use `thread_type = "SLICE"` to retain within-frame parallelism without requiring cross-frame decoder draining. Extend the loader regression test to assert the selected threading mode.

## Testing
- Focused loader tests: 17 passed, 1 skipped
- Full `video_clip` unit suite: 90 passed, 4 skipped
- Mixed H.264/MJPEG stress test: 240/240 decodes completed
- 1×8 A100 proof: two 1,071-step epochs completed without decoder deadlock

## Checklist
- [x] Bug resolved
- [x] Regression test added
- [x] No unrelated net changes