### PR TITLE
[TAO-2567][Bugfix] Silence optional SAM3 import failures

### DIFF
--- a/nvidia_tao_pytorch/cv/backbone_v2/sam3.py
+++ b/nvidia_tao_pytorch/cv/backbone_v2/sam3.py
@@ -7,13 +7,14 @@ from typing import Optional, Tuple, Union, Any
 import torch
 from torch import nn
 
+from nvidia_tao_pytorch.core.tlt_logging import logger
 from nvidia_tao_pytorch.cv.backbone_v2 import BACKBONE_REGISTRY
 from nvidia_tao_pytorch.cv.backbone_v2.backbone_base import BackboneBase
 
 try:
     from sam3.model_builder import build_sam3_image_model
-except Exception as e:
-    print(f'Failed to import SAM3. Error: {e}')
+except Exception as exc:
+    logger.debug("SAM3 is unavailable: %s", exc)
     build_sam3_image_model = None
 norm_t = Union[Tuple[float, float, float], torch.Tensor]
 

--- a/tests/cv_unit_test/backbone_v2/test_sam3.py
+++ b/tests/cv_unit_test/backbone_v2/test_sam3.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the optional SAM3 backbone dependency."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.cv_unit
+def test_missing_sam3_is_silent_until_requested():
+    """Importing the SAM3 module stays silent when its package is unavailable."""
+    script = """
+import importlib.abc
+import importlib.util
+import sys
+import types
+
+import torch
+
+
+class Registry:
+    def register(self):
+        return lambda factory: factory
+
+
+class BackboneBase(torch.nn.Module):
+    pass
+
+
+class Logger:
+    def __init__(self):
+        self.debug_messages = []
+
+    def debug(self, message, *args):
+        self.debug_messages.append(message % args)
+
+
+class BlockSam3Finder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "sam3" or fullname.startswith("sam3."):
+            raise ModuleNotFoundError("No module named 'sam3'")
+        return None
+
+
+sys.meta_path.insert(0, BlockSam3Finder())
+
+for package_name in (
+    "nvidia_tao_pytorch",
+    "nvidia_tao_pytorch.core",
+    "nvidia_tao_pytorch.cv",
+):
+    package = types.ModuleType(package_name)
+    package.__path__ = []
+    sys.modules[package_name] = package
+
+tlt_logging = types.ModuleType("nvidia_tao_pytorch.core.tlt_logging")
+tlt_logging.logger = Logger()
+sys.modules[tlt_logging.__name__] = tlt_logging
+
+backbone_package_name = "nvidia_tao_pytorch.cv.backbone_v2"
+backbone_package = types.ModuleType(backbone_package_name)
+backbone_package.__path__ = []
+backbone_package.BACKBONE_REGISTRY = Registry()
+sys.modules[backbone_package_name] = backbone_package
+
+backbone_base = types.ModuleType(f"{backbone_package_name}.backbone_base")
+backbone_base.BackboneBase = BackboneBase
+sys.modules[backbone_base.__name__] = backbone_base
+
+module_name = f"{backbone_package_name}.sam3"
+spec = importlib.util.spec_from_file_location(module_name, sys.argv[1])
+sam3 = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = sam3
+spec.loader.exec_module(sam3)
+
+assert sam3.build_sam3_image_model is None
+assert tlt_logging.logger.debug_messages == [
+    "SAM3 is unavailable: No module named 'sam3'"
+]
+try:
+    sam3.get_sam3_model()
+except ImportError as error:
+    assert "pip install git+https://github.com/facebookresearch/sam3.git" in str(error)
+else:
+    raise AssertionError("SAM3 use should fail when its optional package is absent")
+"""
+    sam3_path = Path(__file__).resolve().parents[3].joinpath(
+        "nvidia_tao_pytorch",
+        "cv",
+        "backbone_v2",
+        "sam3.py",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(sam3_path)],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Failed to import SAM3" not in result.stdout
+    assert "Failed to import SAM3" not in result.stderr


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Route the optional SAM3 import diagnostic through the TAO debug logger instead of printing it during package initialization.
- Preserve the existing actionable `ImportError` when a SAM3 model is explicitly requested.
- Add a focused regression test covering both silent package import and explicit SAM3 access without the optional dependency.

### Why are the changes needed?

`backbone_v2` eagerly imports the optional SAM3 integration during package initialization. The guarded import printed `Failed to import SAM3` whenever the dependency was absent, even when the active workflow did not use SAM3.

TAO Data Services installs and imports TAO PyTorch modules for CLIP image embeddings, so a successful five-round DEFT PAS run emitted the false failure 33 times across otherwise passing stages. This made log-based CI and QA checks report false failures. The original exception remains available when `TAO_LOGGING_LEVEL=DEBUG` is enabled.

### Related issues

- [TAO-2567](https://jirasw.nvidia.com/browse/TAO-2567) / [NVBug 6586747](https://nvbugspro.nvidia.com/bug/6586747)

### Does this PR introduce _any_ user-facing change?

Yes. Non-SAM3 workflows no longer print a misleading SAM3 import failure when the optional dependency is absent. Explicit SAM3 use still raises the existing actionable installation error.

### How was this patch tested?

Using the exact ARM64 image pinned in `docker/manifest.json`:

```text
python -m pytest -q tests/cv_unit_test/backbone_v2/test_sam3.py

1 passed
```

The configured static checks passed:

```text
license header: Passed
pylint: Passed (10.00/10)
pydocstyle: Passed
flake8: Passed
git diff --check: Passed
Python compilation: Passed
DCO sign-off: Passed
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)

### Release note

Non-SAM3 TAO workflows no longer emit a false SAM3 import failure when the optional dependency is not installed.

### Checklist

- [X] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [X] I have read the contributing guidelines
- [X] The code follows the project's style, and lint and format checks pass locally
- [X] I added or updated tests covering this change
- [ ] All tests pass locally; the focused regression test passes and hosted `/build` CI is requested below
- [ ] I added or updated documentation
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [X] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [X] No secrets, credentials, proprietary data, or customer data are included in this PR
- [X] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

The broad optional-import guard is intentionally preserved so a partially installed or incompatible SAM3 package cannot break unrelated backbone imports. This patch replaces only the import-time print with the existing TAO debug logger; `get_sam3_model()` retains the actionable error for explicit use. The regression test loads the module in an isolated subprocess because importing the full registry under the local ARM environment reaches an unrelated encrypted native extension before the assertion can run. No TAO Data Services source change is required; downstream images only need to consume the updated TAO PyTorch package.
