### PR TITLE
[TLT-5952][Bugfix] Use eval_margin for in-training Visual ChangeNet classify metrics

### DIFF
--- a/nvidia_tao_pytorch/config/visual_changenet/default_config.py
+++ b/nvidia_tao_pytorch/config/visual_changenet/default_config.py
@@ -166,7 +166,7 @@ class CNModelClassifyConfig:
         default_value=2.0,
         valid_min=0,
         valid_max="inf",
-        description="Evaluation threshold score for contrastive loss",
+        description="Score threshold separating PASS from FAIL in evaluation and in-training validation metrics. Euclidean distance for difference_module=euclidean; softmax probability in (0, 1) for difference_module=learnable.",
         automl_enabled="TRUE"
     )
     embedding_vectors: int = INT_FIELD(

--- a/nvidia_tao_pytorch/cv/visual_changenet/classification/models/cn_pl_model.py
+++ b/nvidia_tao_pytorch/cv/visual_changenet/classification/models/cn_pl_model.py
@@ -19,6 +19,7 @@
 
 import logging
 import os
+import warnings
 import pytorch_lightning as pl
 import torch
 from torch.optim import lr_scheduler
@@ -72,8 +73,9 @@ class ChangeNetPlModel(TAOLightningModule):
         self._build_criterion()
 
         self.tensorboard = experiment_spec.train.tensorboard
-        self.train_metrics = AOIMetrics()
-        self.val_metrics = AOIMetrics()
+        metric_margin = self._resolve_metric_margin()
+        self.train_metrics = AOIMetrics(metric_margin)
+        self.val_metrics = AOIMetrics(metric_margin)
         self.dm = dm
 
         self.checkpoint_filename = 'changenet_model_classify'
@@ -103,6 +105,26 @@ class ChangeNetPlModel(TAOLightningModule):
                 )
             self.class_weights = torch.tensor(cls_weight)
             self.criterion = nn.CrossEntropyLoss(weight=self.class_weights)
+
+    def _resolve_metric_margin(self):
+        """Resolve the score threshold for in-training train/val AOIMetrics.
+
+        Uses model.classify.eval_margin so in-training validation matches the
+        standalone evaluate action. The learnable difference module emits softmax
+        probabilities in [0, 1]; a margin above 1.0 there can never be exceeded
+        and every sample would be scored PASS, so fall back to 0.5 with a warning.
+        """
+        margin = self.model_config.classify.eval_margin
+        if self.difference_module == "learnable" and margin > 1.0:
+            warnings.warn(
+                f"model.classify.eval_margin={margin} cannot threshold a softmax "
+                "probability (difference_module='learnable'); falling back to 0.5 "
+                "for in-training val_acc/val_fpr. Set eval_margin in (0, 1) to "
+                "silence this warning.",
+                UserWarning,
+            )
+            margin = 0.5
+        return margin
 
     def setup(self, stage):
         """Validate the configured training loss only when training is requested."""

--- a/nvidia_tao_pytorch/cv/visual_changenet/config/default_config.py
+++ b/nvidia_tao_pytorch/cv/visual_changenet/config/default_config.py
@@ -58,7 +58,7 @@ class CNModelClassifyConfig:
     """CN Model Classification config."""
 
     train_margin_euclid: float = FLOAT_FIELD(value=2.0, default_value=2.0, valid_min=1, valid_max="inf", description="Contrastive loss training margin", automl_enabled="TRUE")
-    eval_margin: float = FLOAT_FIELD(value=2.0, default_value=2.0, valid_min=0, valid_max="inf", description="Evaluation threshold score for contrastive loss", automl_enabled="TRUE")
+    eval_margin: float = FLOAT_FIELD(value=2.0, default_value=2.0, valid_min=0, valid_max="inf", description="Score threshold separating PASS from FAIL in evaluation and in-training validation metrics. Euclidean distance for difference_module=euclidean; softmax probability in (0, 1) for difference_module=learnable.", automl_enabled="TRUE")
     embedding_vectors: int = INT_FIELD(value=5, default_value=5, valid_min=1, valid_max="inf", description="Number of embedding vectors - architecture 1", automl_enabled="TRUE")
     embed_dec: int = INT_FIELD(value=5, default_value=5, valid_min=1, valid_max="inf", description="Number of embedding vectors - architecture 2", automl_enabled="TRUE")
     learnable_difference_modules: int = INT_FIELD(value=4, default_value=4, valid_min=1, valid_max=4, description="Number of learnable difference modules", automl_enabled="TRUE")

--- a/tests/cv_unit_test/visual_changenet/test_classification_model_contracts.py
+++ b/tests/cv_unit_test/visual_changenet/test_classification_model_contracts.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 from omegaconf import OmegaConf
 import pytest
+import torch
 import torch.nn as nn
 
 from nvidia_tao_pytorch.config.visual_changenet.default_config import ExperimentConfig
@@ -77,3 +78,65 @@ def test_training_rejects_loss_that_does_not_match_architecture(
         match=f"requires train.classify.loss='{expected_loss}'",
     ):
         model.setup("fit")
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    ("difference_module", "loss", "eval_margin", "expected_margin"),
+    (
+        ("learnable", "ce", 0.3, 0.3),
+        ("euclidean", "contrastive", 2.0, 2.0),
+    ),
+)
+def test_training_metrics_use_eval_margin(
+    monkeypatch, difference_module, loss, eval_margin, expected_margin
+):
+    """In-training train/val metrics threshold at eval_margin, like evaluate."""
+    spec = OmegaConf.structured(ExperimentConfig())
+    spec.model.classify.difference_module = difference_module
+    spec.model.classify.eval_margin = eval_margin
+    spec.train.classify.loss = loss
+    monkeypatch.setattr(cn_pl_model, "build_model", mock.Mock(return_value=nn.Linear(2, 2)))
+    model = cn_pl_model.ChangeNetPlModel(spec, dm=mock.Mock(), export=False)
+
+    assert float(model.train_metrics.margin) == expected_margin
+    assert float(model.val_metrics.margin) == expected_margin
+
+
+@pytest.mark.cv_unit
+def test_learnable_degenerate_margin_falls_back(monkeypatch):
+    """learnable + eval_margin > 1.0 warns and falls back to 0.5 (NVBug 6662965)."""
+    spec = OmegaConf.structured(ExperimentConfig())
+    spec.model.classify.difference_module = "learnable"
+    spec.model.classify.eval_margin = 2.0  # dataclass default: the degenerate case
+    spec.train.classify.loss = "ce"
+    monkeypatch.setattr(cn_pl_model, "build_model", mock.Mock(return_value=nn.Linear(2, 2)))
+
+    with pytest.warns(UserWarning, match="eval_margin"):
+        model = cn_pl_model.ChangeNetPlModel(spec, dm=mock.Mock(), export=False)
+
+    assert float(model.val_metrics.margin) == 0.5
+
+
+@pytest.mark.cv_unit
+def test_val_metrics_discriminate_on_probability_scores(monkeypatch):
+    """Regression: probability scores must actually move val_acc/val_fpr."""
+    spec = OmegaConf.structured(ExperimentConfig())
+    spec.model.classify.difference_module = "learnable"
+    spec.model.classify.eval_margin = 0.3
+    spec.train.classify.loss = "ce"
+    monkeypatch.setattr(cn_pl_model, "build_model", mock.Mock(return_value=nn.Linear(2, 2)))
+    model = cn_pl_model.ChangeNetPlModel(spec, dm=mock.Mock(), export=False)
+
+    # 3 PASS (one above threshold -> false alarm), 2 FAIL both correctly caught.
+    # With the old margin=2.0 every score is below threshold, so accuracy
+    # collapses to the split PASS ratio (60%) and false_alarm to 0.
+    scores = torch.tensor([0.1, 0.2, 0.6, 0.85, 0.9])
+    labels = torch.tensor([0, 0, 0, 1, 1])
+    model.val_metrics.update(scores, labels)
+    result = model.val_metrics.compute()
+
+    pass_ratio = 60.0
+    assert result["total_accuracy"].item() == pytest.approx(80.0)
+    assert result["total_accuracy"].item() != pass_ratio  # the old degenerate value
+    assert result["false_alarm"].item() > 0.0


### PR DESCRIPTION
### What changes are proposed in this pull request?

`ChangeNetPlModel.__init__` built its in-training metrics as bare
`AOIMetrics()` / `AOIMetrics()`, which falls back to the euclidean-distance
default `margin=2.0`. This PR resolves that threshold from
`model.classify.eval_margin` instead, via a new `_resolve_metric_margin()`
helper, so in-training validation uses the same operating point as the
standalone `evaluate` action.

```python
metric_margin = self._resolve_metric_margin()
self.train_metrics = AOIMetrics(metric_margin)
self.val_metrics = AOIMetrics(metric_margin)
```

`_resolve_metric_margin()` also guards the degenerate pairing: when
`difference_module='learnable'` is combined with an `eval_margin > 1.0`, the
threshold can never be exceeded, so it emits a `UserWarning` and falls back to
`0.5`. `eval_margin` is left at its `2.0` default — changing the default would
alter euclidean-mode behavior — and the `eval_margin` field description in both
config definitions is updated to say what the value actually means for each
difference module.

### Why are the changes needed?

For `difference_module: learnable` the comparison score is
`softmax(output_diff)[:, 1]`, a probability in `[0, 1]`. `AOIMetrics.update()`
predicts FAIL only when `score > margin`, so at `margin=2.0` no sample can ever
be predicted FAIL: every sample is scored PASS. The consequences are that
`val_acc` collapses to the validation split's PASS ratio and `val_fpr` is
pinned at `0.0`, both constant for the entire run.

That makes `monitor: val_acc` / `val_fpr` checkpoint selection a no-op, breaks
any AutoML or downstream ranking that reads those metrics, and means
in-training validation and standalone `evaluate` report different numbers under
the same metric names for the same checkpoint and the same CSV. The test path
already did this correctly — `on_test_epoch_start` has always built
`AOIMetrics(model.classify.eval_margin)` — so this aligns training with
evaluation rather than introducing a new convention.

### Related issues

N/A (tracked internally as NVBug 6662965).

### Does this PR introduce _any_ user-facing change?

Yes — this is a behavior change for `difference_module: learnable` runs.

Before, on a validation split that is 98.6% PASS:

```
val_acc = 98.60, val_fpr = 0.00   # every epoch, regardless of the model
```

After, at the same checkpoint and `eval_margin: 0.3`:

```
val_acc = 1.40,  val_fpr = 100.00   # matches `visual_changenet evaluate` exactly
```

The new numbers are the correct ones, but they are real metrics rather than
constants, so any workflow that ranks or selects checkpoints on `val_acc` /
`val_fpr` may now pick a different checkpoint than it did before. That is the
intent of the fix, and it is worth knowing before rerunning existing pipelines.

Euclidean mode is unchanged unless a user had configured `eval_margin` to
something other than the previously hardcoded `2.0`; in that case in-training
metrics now honor the threshold that was already configured for evaluation.

Deliberately untouched:

- `_compute_val_far()` / `val_far` — threshold-free by construction and
  therefore never affected by this bug.
- `on_test_epoch_start` and the rest of the `evaluate` path — already correct.
- The `eval_margin` default of `2.0` and all euclidean-mode defaults.

### How was this patch tested?

Three unit tests added to
`tests/cv_unit_test/visual_changenet/test_classification_model_contracts.py`:

- `test_training_metrics_use_eval_margin` — train/val metrics threshold at
  `eval_margin` for both difference modules.
- `test_learnable_degenerate_margin_falls_back` — `learnable` + `eval_margin >
  1.0` warns and falls back to `0.5`.
- `test_val_metrics_discriminate_on_probability_scores` — regression guard that
  probability-valued scores actually move `total_accuracy` and `false_alarm`
  off the degenerate values.

```
$ pytest -q tests/cv_unit_test/visual_changenet/test_classification_model_contracts.py \
           tests/cv_unit_test/optical_inspection/test_metrics.py
12 passed
```

All three new tests fail against the unpatched module (3 failed, 5 passed), and
the pre-existing contract and `AOIMetrics` tests are unaffected.

Functionally verified end to end on a learnable AOI classify run: a 2-epoch
training job now reports `val_acc` / `val_fpr` that are no longer equal to the
split PASS ratio and `0.0`, and `visual_changenet evaluate` on the same
checkpoint and the same CSV at `eval_margin: 0.3` reproduces them exactly
(`Total Accuracy 1.4`, `False Alarm 100.0`). Running `evaluate` at
`eval_margin: 2.0` reproduces the old degenerate pair (`Total Accuracy 98.6`,
`False Alarm 0.0`), confirming the root cause. The `UserWarning` was confirmed
to fire on the `learnable` + `2.0` pairing.

`pre-commit` (license header, pylint, pydocstyle, flake8, secret scan) passes on
all four changed files.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)

### Release note

```release-note
Fixed in-training val_acc and val_fpr for Visual ChangeNet classification, which were constant, meaningless values for difference_module: learnable; they are now thresholded at model.classify.eval_margin and agree with the standalone evaluate action.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

The one judgement call worth scrutinizing is the `0.5` fallback for `learnable`
+ `eval_margin > 1.0`. The alternative is to raise, but that would break every
existing spec that leaves `eval_margin` at its `2.0` default — including specs
whose runs are otherwise fine because they only monitor `val_loss` or
`val_far`. A warned fallback keeps those runs working while making the
misconfiguration visible.

Deliberately out of scope: changing the `eval_margin` default to something
inside `(0, 1)`. That would silently move the euclidean-mode operating point,
which is a separate decision from fixing the learnable path.
