### PR TITLE
fix(video-clip): harden export and PEFT reporting

### DIFF
--- a/nvidia_tao_pytorch/core/utils/default_specs.py
+++ b/nvidia_tao_pytorch/core/utils/default_specs.py
@@ -11,6 +11,7 @@ from os.path import abspath, dirname, exists, join
 
 from omegaconf import MISSING, OmegaConf
 from dataclasses import dataclass, is_dataclass
+from typing import Optional
 
 from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
 from nvidia_tao_pytorch.core.tlt_logging import logging
@@ -147,7 +148,7 @@ class DefaultConfig:
     """This is a structured config for generating default specs."""
 
     # Minimalistic experiment manager.
-    results_dir: str = MISSING
+    results_dir: Optional[str] = None
     module_name: str = MISSING
 
 
@@ -171,6 +172,13 @@ def main(cfg: DefaultConfig) -> None:
         logging.error(error_msg)
         raise ValueError(error_msg)
 
+    module_path = f"nvidia_tao_pytorch.config.{cfg.module_name}.default_config"
+    if not cfg.results_dir:
+        imported_module = import_module_from_path(module_path)
+        experiment_config = get_experiment_config(imported_module)
+        print(OmegaConf.to_yaml(OmegaConf.structured(experiment_config)), end="")
+        return
+
     # Create results directory if it doesn't exist
     if not exists(cfg.results_dir):
         makedirs(cfg.results_dir, exist_ok=True)
@@ -183,7 +191,6 @@ def main(cfg: DefaultConfig) -> None:
         logging.warning(f"Output file already exists and will be overwritten: {output_path}")
 
     # Import the module and get the ExperimentConfig dataclass
-    module_path = f"nvidia_tao_pytorch.config.{cfg.module_name}.default_config"
     try:
         imported_module = import_module_from_path(module_path)
         experiment_config = get_experiment_config(imported_module)

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/adapters/internvideo2clip.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/adapters/internvideo2clip.py
@@ -113,6 +113,7 @@ class InternVideo2CLIP(BaseCLIPAdapter):
         use_flash_attn=False,
         use_fused_rmsnorm=False,
         use_fused_mlp=False,
+        log_parameters=True,
     ):
         """Initialize InternVideo2-CLIP L14 from a whole-model or component ckpts.
 
@@ -179,7 +180,8 @@ class InternVideo2CLIP(BaseCLIPAdapter):
 
         self.backbone.temp.requires_grad = False
         self.tokenizer = InternVideo2Tokenizer(self.backbone.tokenizer)
-        self._log_parameters(freeze_vision_encoder, freeze_text_encoder)
+        if log_parameters:
+            self._log_parameters(freeze_vision_encoder, freeze_text_encoder)
 
     def _log_parameters(self, freeze_vision, freeze_text):
         """Log trainable parameter summary."""

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/builders.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/builders.py
@@ -403,6 +403,7 @@ def build_internvideo2clip_model(
     model_cfg,
     logit_scale_init=4.605170185988092,
     logit_bias_init=0.0,
+    log_parameters=True,
 ):
     """Build InternVideo2-CLIP L14 with preprocessing and tokenizer."""
     model = InternVideo2CLIP(
@@ -420,6 +421,7 @@ def build_internvideo2clip_model(
         use_flash_attn=model_cfg.use_flash_attn,
         use_fused_rmsnorm=model_cfg.use_fused_rmsnorm,
         use_fused_mlp=model_cfg.use_fused_mlp,
+        log_parameters=log_parameters,
     )
     transform = InternVideo2FrameTransform(image_size=model_cfg.image_size)
     return model, transform, transform, model.tokenizer

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/pl_video_clip_model.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/pl_video_clip_model.py
@@ -121,6 +121,12 @@ class VideoCLIPPlModel(TAOLightningModule):
         self.lora_stats = None
         if self.peft_enabled:
             self.lora_stats = inject_lora(self.model, peft_cfg)
+            trainable = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
+            total = sum(p.numel() for p in self.model.parameters())
+            logging.info(
+                "LoRA trainable parameter summary: %s trainable / %s total (%.4f%%)",
+                f"{trainable:,}", f"{total:,}", 100.0 * trainable / max(total, 1),
+            )
 
         # Check if retrieval validation is configured (video_text only).
         val_cfg = getattr(self.experiment_spec.dataset, 'val', None)

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/tokenizers.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/tokenizers.py
@@ -33,6 +33,7 @@ Functions:
     load_tokenizer: Load tokenizer from disk
 """
 
+import json
 import os
 from typing import List, Optional
 
@@ -193,7 +194,7 @@ def save_tokenizer(
     """
     os.makedirs(output_dir, exist_ok=True)
 
-    inner_tokenizer = tokenizer._tokenizer
+    inner_tokenizer = getattr(tokenizer, '_tokenizer', tokenizer)
 
     if isinstance(inner_tokenizer, SigLIP2WrappedTokenizer):
         # SigLIP2: save the HuggingFace processor's tokenizer
@@ -231,13 +232,47 @@ def save_tokenizer(
             )
             ctx_len = text_cfg.get("context_length", 77)
 
-        hf_tokenizer = AutoTokenizer.from_pretrained(hf_tokenizer_name)
-        hf_tokenizer.model_max_length = ctx_len
-        hf_tokenizer.save_pretrained(output_dir)
-        logging.info(
-            "Saved equivalent HuggingFace tokenizer (%s) to %s",
-            hf_tokenizer_name, output_dir
-        )
+        raw_tokenizer = inner_tokenizer
+        while hasattr(raw_tokenizer, '_tokenizer'):
+            raw_tokenizer = raw_tokenizer._tokenizer
+        if hasattr(raw_tokenizer, 'tokenizer'):
+            raw_tokenizer = raw_tokenizer.tokenizer
+        if hasattr(raw_tokenizer, 'encoder') and hasattr(raw_tokenizer, 'bpe_ranks'):
+            with open(os.path.join(output_dir, 'vocab.json'), 'w', encoding='utf-8') as stream:
+                json.dump(raw_tokenizer.encoder, stream, ensure_ascii=False)
+            ranked_merges = sorted(raw_tokenizer.bpe_ranks, key=raw_tokenizer.bpe_ranks.get)
+            with open(os.path.join(output_dir, 'merges.txt'), 'w', encoding='utf-8') as stream:
+                stream.write('#version: 0.2\n')
+                stream.writelines(f"{left} {right}\n" for left, right in ranked_merges)
+            tokenizer_config = {
+                'tokenizer_class': 'CLIPTokenizer',
+                'model_max_length': ctx_len,
+                'bos_token': '<|startoftext|>',
+                'eos_token': '<|endoftext|>',
+                'unk_token': '<|endoftext|>',
+                'pad_token': '<|endoftext|>',
+            }
+            with open(os.path.join(output_dir, 'tokenizer_config.json'), 'w', encoding='utf-8') as stream:
+                json.dump(tokenizer_config, stream, indent=2)
+            with open(os.path.join(output_dir, 'special_tokens_map.json'), 'w', encoding='utf-8') as stream:
+                json.dump({key: tokenizer_config[key] for key in ('bos_token', 'eos_token', 'unk_token', 'pad_token')}, stream, indent=2)
+            logging.info("Saved in-memory OpenCLIP tokenizer to %s", output_dir)
+        else:
+            try:
+                hf_tokenizer = AutoTokenizer.from_pretrained(
+                    hf_tokenizer_name, local_files_only=True
+                )
+            except OSError as exc:
+                raise RuntimeError(
+                    "Tokenizer export is offline and the model did not expose serializable "
+                    f"tokenizer assets for {hf_tokenizer_name!r}"
+                ) from exc
+            hf_tokenizer.model_max_length = ctx_len
+            hf_tokenizer.save_pretrained(output_dir)
+            logging.info(
+                "Saved cached HuggingFace tokenizer (%s) to %s",
+                hf_tokenizer_name, output_dir
+            )
 
     return output_dir
 

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/video_clip.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/video_clip.py
@@ -108,11 +108,14 @@ def build_model(experiment_config,
         )
 
     if model_type in internvideo2clip_model_configs:
+        peft_cfg = getattr(experiment_config, 'peft', None)
+        peft_enabled = peft_cfg is not None and peft_cfg.enabled
         model, preprocess_train, preprocess_val, tokenizer = (
             build_internvideo2clip_model(
                 model_cfg=experiment_config.model,
                 logit_scale_init=init_logit_scale,
                 logit_bias_init=init_logit_bias,
+                log_parameters=not peft_enabled,
             ))
     elif model_type in radio_model_configs:
         adaptor_name = getattr(

--- a/nvidia_tao_pytorch/multimodal/video_clip/scripts/export.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/scripts/export.py
@@ -17,7 +17,9 @@
 """Export CLIP model to ONNX."""
 
 import copy
+import glob
 import os
+import shutil
 from typing import Optional, Tuple
 
 import numpy as np
@@ -886,7 +888,7 @@ def export_combined_encoder(
         return tmp_onnx_file
 
 
-def run_export(experiment_config: ExperimentConfig) -> None:
+def _run_export_impl(experiment_config: ExperimentConfig) -> None:
     """Run ONNX export for CLIP model.
 
     The encoder_type config option controls the export mode:
@@ -908,6 +910,8 @@ def run_export(experiment_config: ExperimentConfig) -> None:
 
     # Get export parameters
     model_path = export_config.checkpoint
+    if not model_path:
+        raise ValueError("A trained checkpoint is required for export")
     key = experiment_config.encryption_key
     TLTPyTorchCookbook.set_passphrase(key)
 
@@ -938,7 +942,7 @@ def run_export(experiment_config: ExperimentConfig) -> None:
 
     device = 'cpu' if on_cpu else 'cuda'
 
-    # Load model from checkpoint or build from HuggingFace pretrained weights
+    # Load the trained model checkpoint.
     if model_path:
         logging.info(f"Loading model from checkpoint: {model_path}")
         # Preservation regularization is training-only; skip the frozen-teacher
@@ -1069,6 +1073,26 @@ def run_export(experiment_config: ExperimentConfig) -> None:
         adaptor_name=getattr(experiment_config.model, 'adaptor_name', None),
     )
     logging.info(f"Tokenizer saved to {tokenizer_dir}")
+
+
+def run_export(experiment_config: ExperimentConfig) -> None:
+    """Export atomically enough that a failed attempt is safely retryable."""
+    export_config = experiment_config.export
+    model_path = export_config.checkpoint
+    if not model_path:
+        raise ValueError("A trained checkpoint is required for export")
+    output_file = export_config.onnx_file or f"{os.path.splitext(model_path)[0]}.onnx"
+    base_name = os.path.splitext(os.path.realpath(output_file))[0]
+    before = set(glob.glob(f"{base_name}*"))
+    try:
+        _run_export_impl(experiment_config)
+    except Exception:
+        for artifact in set(glob.glob(f"{base_name}*")) - before:
+            if os.path.isdir(artifact) and not os.path.islink(artifact):
+                shutil.rmtree(artifact)
+            else:
+                os.remove(artifact)
+        raise
 
 
 spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/core/test_default_specs_stdout.py
+++ b/tests/core/test_default_specs_stdout.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for default_specs stdout mode."""
+
+from omegaconf import OmegaConf
+
+from nvidia_tao_pytorch.core.utils.default_specs import DefaultConfig
+
+
+def test_results_dir_is_optional_in_structured_config():
+    config = OmegaConf.structured(DefaultConfig)
+    assert config.results_dir is None

--- a/tests/multimodal_unit_test/video_clip/test_scripts.py
+++ b/tests/multimodal_unit_test/video_clip/test_scripts.py
@@ -39,6 +39,7 @@ from nvidia_tao_pytorch.multimodal.video_clip.scripts.export import (
     VALID_ENCODER_TYPES,
     _get_video_export_num_frames,
 )
+from nvidia_tao_pytorch.multimodal.video_clip.scripts import export as export_module
 from nvidia_tao_pytorch.multimodal.video_clip.utils.embedding_io import (
     read_embeddings_h5,
     text_to_video_search,
@@ -321,3 +322,25 @@ class TestExportHelpers:
 
         m.num_frames = 0  # non-positive -> None
         assert _get_video_export_num_frames(m) is None
+
+    def test_export_requires_trained_checkpoint(self, tmp_path):
+        experiment = SimpleNamespace(export=SimpleNamespace(
+            checkpoint=None, onnx_file=str(tmp_path / "model.onnx")
+        ))
+        with pytest.raises(ValueError, match="trained checkpoint is required"):
+            export_module.run_export(experiment)
+
+    def test_failed_export_removes_partial_artifacts(self, monkeypatch, tmp_path):
+        output = tmp_path / "model.onnx"
+        experiment = SimpleNamespace(export=SimpleNamespace(
+            checkpoint="trained.pth", onnx_file=str(output)
+        ))
+        def fail(_experiment):
+            output.write_bytes(b"partial")
+            (tmp_path / "model_config.yaml").write_text("partial")
+            raise RuntimeError("late failure")
+        monkeypatch.setattr(export_module, "_run_export_impl", fail)
+        with pytest.raises(RuntimeError, match="late failure"):
+            export_module.run_export(experiment)
+        assert not output.exists()
+        assert not (tmp_path / "model_config.yaml").exists()

--- a/tests/multimodal_unit_test/video_clip/test_tokenizer_export_offline.py
+++ b/tests/multimodal_unit_test/video_clip/test_tokenizer_export_offline.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for offline VideoCLIP tokenizer export."""
+
+import json
+
+from nvidia_tao_pytorch.multimodal.video_clip.model.tokenizers import save_tokenizer
+
+
+def test_in_memory_openclip_tokenizer_exports_without_hub(monkeypatch, tmp_path):
+    class RawTokenizer:
+        encoder = {"<|startoftext|>": 0, "<|endoftext|>": 1, "hello</w>": 2}
+        bpe_ranks = {("h", "e"): 0, ("he", "llo</w>"): 1}
+
+    class ClipTokenizer:
+        context_length = 77
+        tokenizer = RawTokenizer()
+
+    class Wrapper:
+        _tokenizer = ClipTokenizer()
+
+    monkeypatch.setattr(
+        "nvidia_tao_pytorch.multimodal.video_clip.model.tokenizers.AutoTokenizer.from_pretrained",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("network lookup")),
+    )
+    save_tokenizer(Wrapper(), str(tmp_path), "internvideo2-clip-l14")
+    assert json.loads((tmp_path / "vocab.json").read_text())["hello</w>"] == 2
+    assert (tmp_path / "merges.txt").read_text().startswith("#version: 0.2")
+    assert json.loads((tmp_path / "tokenizer_config.json").read_text())["model_max_length"] == 77


### PR DESCRIPTION
## Summary

- report trainable parameters after LoRA injection instead of before it
- allow VideoCLIP default-spec rendering without a mandatory results directory
- reject export without a trained checkpoint and clean up artifacts created by a failed export attempt
- serialize the in-memory OpenCLIP tokenizer so offline export does not require Hugging Face access

## NVBugs

6670447, 6670205, 6670035, 6670031, and 6670019.

## Validation

- focused default-spec regression passed
- PEFT ordering, null-checkpoint, transactional-cleanup, and offline-tokenizer boundary reproducers passed after failing on the baseline
- affected Python modules compile successfully
- the full VideoCLIP module suite was not runnable in the local environment because Lightning is not installed
