### PR TITLE
[TAO-1796][Bugfix] video_clip: harden dependencies and export

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,23 +114,26 @@ EOF
 RUN apt-get purge -y --auto-remove yasm nasm && rm -rf /var/lib/apt/lists/*
 
 COPY docker/requirements-pip.txt requirements-pip.txt
-RUN pip install --upgrade pip \
-  && pip install --no-build-isolation -r requirements-pip.txt \
-  && rm requirements-pip.txt
-
-# Rebuild PyAV against the approved system FFmpeg so no PyPI wheel can bring a
-# bundled av.libs/ copy of libx264/libx265. The requirements pin installs the
-# wheel; this replaces it with a source build linked against /usr/local, which
-# inherits the codec allow-list asserted above. Since h264_cuvid is then the only
-# registered H.264 decoder, generic h264 resolves to NVDEC with no extra library.
+# Build PyAV against the approved system FFmpeg before the bulk requirements install,
+# so pip sees the pinned version as already satisfied and never installs the PyPI wheel
+# with its bundled av.libs/ copy of libx264/libx265. Cython 3.2.4 rejects PyAV 17.1.0's
+# pyio callback declarations, so constrain only the isolated build environment to 3.1.x.
+# The resulting extension links against /usr/local and inherits the codec allow-list
+# asserted above. Since h264_cuvid is then the only registered H.264 decoder, generic
+# h264 resolves to NVDEC with no extra library.
 RUN <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH:-}"
 
+av_requirement="$(grep -E '^av==' requirements-pip.txt)"
+test -n "${av_requirement}" || { echo "ERROR: PyAV pin missing from requirements-pip.txt" >&2; exit 1; }
+printf '%s\n' 'cython==3.1.6' > /tmp/pyav-build-constraints.txt
 pip uninstall -y av decord || true
-pip install --no-cache-dir --force-reinstall --no-deps --no-binary=av "av==17.1.0"
+pip install --no-cache-dir --force-reinstall --no-deps --no-binary=av \
+  --build-constraint /tmp/pyav-build-constraints.txt "${av_requirement}"
+rm /tmp/pyav-build-constraints.txt
 
 site_packages="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
 bad_libs="$(find "${site_packages}" \
@@ -150,6 +153,10 @@ import av
 print("PyAV", av.__version__, "linked against the restricted system FFmpeg")
 PY_NO_DECORD
 EOF
+
+RUN pip install --upgrade pip \
+  && pip install --no-build-isolation -r requirements-pip.txt \
+  && rm requirements-pip.txt
 
 
 # Set platform-specific library path using uname

--- a/docker/manifest.json
+++ b/docker/manifest.json
@@ -2,7 +2,7 @@
   "registry": "nvcr.io",
   "repository": "nvstaging/tao/tao_pytorch_base_image",
   "digests": {
-    "x86": "sha256:0dda18f23cbdb62177afa1805a900d29fa4feb7e81feaecf0208495e1db4ccbe",
-    "arm": "sha256:0edf38a0afd615dbbe169e96d5f00e7f7e1bbd8818221b0103541f81b61c4327"
+    "x86": "sha256:224a161014b5c7ac864e5d1055600d4d27c08a2e23e89bc6e5102a474d2ffae2",
+    "arm": "sha256:2e095fb1db53458140769418dcd3c0cae46042a8554a94b5cb0bea86ec8811c0"
   }
 }

--- a/docker/requirements-pip.txt
+++ b/docker/requirements-pip.txt
@@ -7,8 +7,8 @@ beartype==0.22.9
 braceexpand
 # video decoder for video_clip: OpenCV is built WITH_FFMPEG=OFF and the restricted
 # ffmpeg (TAO-2183 / FF-4) has no pipe protocol or rawvideo muxer, so PyAV is the only
-# decoder in the image. This wheel is not what ships — see the --no-binary=av rebuild
-# in docker/Dockerfile.
+# decoder in the image. docker/Dockerfile source-builds this pin before installing
+# the complete requirements file, preventing pip from installing the bundled wheel.
 av==17.1.0
 einops
 # sam3 is installed --no-deps from its own Dockerfile layer: its setup.py

--- a/nvidia_tao_pytorch/config/video_clip/default_config.py
+++ b/nvidia_tao_pytorch/config/video_clip/default_config.py
@@ -19,6 +19,8 @@
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
+from omegaconf import MISSING
+
 from nvidia_tao_pytorch.config.common.common_config import (
     CommonExperimentConfig,
     GenTrtEngineConfig,
@@ -818,9 +820,9 @@ class VideoCLIPRunConfig:
     base with their task-specific fields.
     """
 
-    checkpoint: Optional[str] = STR_FIELD(
-        value=None,
-        default_value=None,
+    checkpoint: str = STR_FIELD(
+        value=MISSING,
+        default_value="",
         description="Required path to a trained model checkpoint (.ckpt or .pth) "
                     "for evaluation or inference.",
         display_name="Checkpoint Path",
@@ -986,9 +988,9 @@ class VideoCLIPInferenceConfig(VideoCLIPRunConfig):
 class VideoCLIPExportConfig:
     """ONNX export configuration for VideoCLIP models."""
 
-    checkpoint: Optional[str] = STR_FIELD(
-        value=None,
-        default_value=None,
+    checkpoint: str = STR_FIELD(
+        value=MISSING,
+        default_value="",
         description="Required path to a trained TAO model checkpoint "
                     "(.ckpt or .pth).",
         display_name="Checkpoint Path",

--- a/nvidia_tao_pytorch/config/video_clip/default_config.py
+++ b/nvidia_tao_pytorch/config/video_clip/default_config.py
@@ -989,8 +989,8 @@ class VideoCLIPExportConfig:
     checkpoint: Optional[str] = STR_FIELD(
         value=None,
         default_value=None,
-        description="Path to trained model checkpoint (.ckpt or .pth). "
-                    "If null, exports directly from HuggingFace pretrained weights.",
+        description="Required path to a trained TAO model checkpoint "
+                    "(.ckpt or .pth).",
         display_name="Checkpoint Path",
     )
     onnx_file: Optional[str] = STR_FIELD(

--- a/nvidia_tao_pytorch/core/utils/default_specs.py
+++ b/nvidia_tao_pytorch/core/utils/default_specs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 from os import makedirs, listdir
 from os.path import abspath, dirname, exists, join
+from typing import Optional
 
 from omegaconf import MISSING, OmegaConf
 from dataclasses import dataclass, is_dataclass
@@ -147,7 +148,7 @@ class DefaultConfig:
     """This is a structured config for generating default specs."""
 
     # Minimalistic experiment manager.
-    results_dir: str = MISSING
+    results_dir: Optional[str] = None
     module_name: str = MISSING
 
 
@@ -171,16 +172,16 @@ def main(cfg: DefaultConfig) -> None:
         logging.error(error_msg)
         raise ValueError(error_msg)
 
-    # Create results directory if it doesn't exist
-    if not exists(cfg.results_dir):
-        makedirs(cfg.results_dir, exist_ok=True)
-        logging.info(f"Created results directory: {cfg.results_dir}")
+    output_path = None
+    if cfg.results_dir:
+        # Create results directory if it doesn't exist
+        if not exists(cfg.results_dir):
+            makedirs(cfg.results_dir, exist_ok=True)
+            logging.info(f"Created results directory: {cfg.results_dir}")
 
-    # Set output file path
-    output_filename = "experiment.yaml"
-    output_path = join(cfg.results_dir, output_filename)
-    if exists(output_path):
-        logging.warning(f"Output file already exists and will be overwritten: {output_path}")
+        output_path = join(cfg.results_dir, "experiment.yaml")
+        if exists(output_path):
+            logging.warning(f"Output file already exists and will be overwritten: {output_path}")
 
     # Import the module and get the ExperimentConfig dataclass
     module_path = f"nvidia_tao_pytorch.config.{cfg.module_name}.default_config"
@@ -188,11 +189,14 @@ def main(cfg: DefaultConfig) -> None:
         imported_module = import_module_from_path(module_path)
         experiment_config = get_experiment_config(imported_module)
 
-        # Generate YAML from dataclass
-        dataclass_to_yaml(experiment_config, output_path)
-
-        # Success logging
-        logging.info(f"Default specification file for {cfg.module_name} generated at '{output_path}'")
+        if output_path:
+            dataclass_to_yaml(experiment_config, output_path)
+            logging.info(
+                f"Default specification file for {cfg.module_name} generated at '{output_path}'"
+            )
+        else:
+            config = OmegaConf.structured(experiment_config)
+            print(OmegaConf.to_yaml(config), end="")
 
     except ImportError as e:
         error_msg = f"Failed to import module '{module_path}': {str(e)}"

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/adapters/internvideo2clip.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/adapters/internvideo2clip.py
@@ -113,6 +113,7 @@ class InternVideo2CLIP(BaseCLIPAdapter):
         use_flash_attn=False,
         use_fused_rmsnorm=False,
         use_fused_mlp=False,
+        log_parameters=True,
     ):
         """Initialize InternVideo2-CLIP L14 from a whole-model or component ckpts.
 
@@ -179,7 +180,8 @@ class InternVideo2CLIP(BaseCLIPAdapter):
 
         self.backbone.temp.requires_grad = False
         self.tokenizer = InternVideo2Tokenizer(self.backbone.tokenizer)
-        self._log_parameters(freeze_vision_encoder, freeze_text_encoder)
+        if log_parameters:
+            self._log_parameters(freeze_vision_encoder, freeze_text_encoder)
 
     def _log_parameters(self, freeze_vision, freeze_text):
         """Log trainable parameter summary."""

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/builders.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/builders.py
@@ -403,6 +403,7 @@ def build_internvideo2clip_model(
     model_cfg,
     logit_scale_init=4.605170185988092,
     logit_bias_init=0.0,
+    log_parameters=True,
 ):
     """Build InternVideo2-CLIP L14 with preprocessing and tokenizer."""
     model = InternVideo2CLIP(
@@ -420,6 +421,7 @@ def build_internvideo2clip_model(
         use_flash_attn=model_cfg.use_flash_attn,
         use_fused_rmsnorm=model_cfg.use_fused_rmsnorm,
         use_fused_mlp=model_cfg.use_fused_mlp,
+        log_parameters=log_parameters,
     )
     transform = InternVideo2FrameTransform(image_size=model_cfg.image_size)
     return model, transform, transform, model.tokenizer

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/pl_video_clip_model.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/pl_video_clip_model.py
@@ -121,6 +121,12 @@ class VideoCLIPPlModel(TAOLightningModule):
         self.lora_stats = None
         if self.peft_enabled:
             self.lora_stats = inject_lora(self.model, peft_cfg)
+            trainable = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
+            total = sum(p.numel() for p in self.model.parameters())
+            logging.info(
+                "LoRA trainable parameter summary: %s trainable / %s total (%.4f%%)",
+                f"{trainable:,}", f"{total:,}", 100.0 * trainable / max(total, 1),
+            )
 
         # Check if retrieval validation is configured (video_text only).
         val_cfg = getattr(self.experiment_spec.dataset, 'val', None)

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/tokenizers.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/tokenizers.py
@@ -203,6 +203,9 @@ def _save_openclip_tokenizer(tokenizer, output_dir):
     vocab = dict(tokenizer.encoder)
     # Alias OpenCLIP's padding ID without turning its real token ("!") into a
     # special token, which would change tokenization of ordinary punctuation.
+    # The duplicate ID intentionally makes the Hugging Face decoder map 0 to
+    # <pad>, not "!"; encoding fidelity and explicit padding take precedence
+    # over decode fidelity for this otherwise ambiguous ID.
     vocab["<pad>"] = 0
     with open(vocab_path, "w", encoding="utf-8") as vocab_file:
         json.dump(vocab, vocab_file, ensure_ascii=False)

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/tokenizers.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/tokenizers.py
@@ -33,10 +33,11 @@ Functions:
     load_tokenizer: Load tokenizer from disk
 """
 
+import json
 import os
 from typing import List, Optional
 
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, CLIPTokenizer
 
 from nvidia_tao_pytorch.core.tlt_logging import logging
 from nvidia_tao_pytorch.cv.backbone_v2.text_utils import canonicalize_text
@@ -170,6 +171,61 @@ class OpenCLIPWrappedTokenizer:
         return {'input_ids': result}
 
 
+def _find_openclip_tokenizer(tokenizer):
+    """Find a wrapped OpenCLIP tokenizer with serializable BPE assets."""
+    visited = set()
+    while tokenizer is not None and id(tokenizer) not in visited:
+        visited.add(id(tokenizer))
+        if all(
+            hasattr(tokenizer, attribute)
+            for attribute in (
+                "encoder",
+                "decoder",
+                "bpe_ranks",
+                "context_length",
+                "sot_token_id",
+                "eot_token_id",
+            )
+        ):
+            return tokenizer
+        tokenizer = getattr(
+            tokenizer,
+            "_tokenizer",
+            getattr(tokenizer, "tokenizer", None),
+        )
+    return None
+
+
+def _save_openclip_tokenizer(tokenizer, output_dir):
+    """Save OpenCLIP BPE assets as an equivalent Hugging Face tokenizer."""
+    vocab_path = os.path.join(output_dir, "vocab.json")
+    merges_path = os.path.join(output_dir, "merges.txt")
+    vocab = dict(tokenizer.encoder)
+    # Alias OpenCLIP's padding ID without turning its real token ("!") into a
+    # special token, which would change tokenization of ordinary punctuation.
+    vocab["<pad>"] = 0
+    with open(vocab_path, "w", encoding="utf-8") as vocab_file:
+        json.dump(vocab, vocab_file, ensure_ascii=False)
+    with open(merges_path, "w", encoding="utf-8") as merges_file:
+        merges_file.write("#version: 0.2\n")
+        for first, second in sorted(
+            tokenizer.bpe_ranks,
+            key=tokenizer.bpe_ranks.get,
+        ):
+            merges_file.write(f"{first} {second}\n")
+
+    hf_tokenizer = CLIPTokenizer(
+        vocab_file=vocab_path,
+        merges_file=merges_path,
+        bos_token=tokenizer.decoder[tokenizer.sot_token_id],
+        eos_token=tokenizer.decoder[tokenizer.eot_token_id],
+        unk_token=tokenizer.decoder[tokenizer.eot_token_id],
+        pad_token="<pad>",
+        model_max_length=tokenizer.context_length,
+    )
+    hf_tokenizer.save_pretrained(output_dir)
+
+
 def save_tokenizer(
     tokenizer: CLIPCompatibleTokenizer,
     output_dir: str,
@@ -206,6 +262,12 @@ def save_tokenizer(
         hf_tokenizer.model_max_length = inner_tokenizer._max_length  # e.g. 64 for SigLIP2
         hf_tokenizer.save_pretrained(output_dir)
         logging.info("Saved SigLIP2 tokenizer to %s", output_dir)
+    elif openclip_tokenizer := _find_openclip_tokenizer(tokenizer):
+        _save_openclip_tokenizer(openclip_tokenizer, output_dir)
+        logging.info(
+            "Saved OpenCLIP tokenizer from loaded BPE assets to %s",
+            output_dir,
+        )
     else:
         # OpenCLIP-based (RADIO CLIP, OpenCLIP): save equivalent HuggingFace tokenizer
         from nvidia_tao_pytorch.multimodal.video_clip.utils.model_configs import (

--- a/nvidia_tao_pytorch/multimodal/video_clip/model/video_clip.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/model/video_clip.py
@@ -113,6 +113,7 @@ def build_model(experiment_config,
                 model_cfg=experiment_config.model,
                 logit_scale_init=init_logit_scale,
                 logit_bias_init=init_logit_bias,
+                log_parameters=not experiment_config.peft.enabled,
             ))
     elif model_type in radio_model_configs:
         adaptor_name = getattr(

--- a/nvidia_tao_pytorch/multimodal/video_clip/scripts/export.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/scripts/export.py
@@ -898,8 +898,15 @@ def run_export(experiment_config: ExperimentConfig) -> None:
     experiment_config : ExperimentConfig
         Experiment configuration containing export settings.
     """
-    register_checkpoint_safe_globals()
     export_config = experiment_config.export
+    model_path = export_config.checkpoint
+    if not model_path:
+        raise ValueError(
+            "A trained checkpoint is required for export. Set "
+            "export.checkpoint to a valid TAO checkpoint."
+        )
+
+    register_checkpoint_safe_globals()
     gpu_id = export_config.gpu_id
     on_cpu = export_config.on_cpu
 
@@ -907,7 +914,6 @@ def run_export(experiment_config: ExperimentConfig) -> None:
         torch.cuda.set_device(gpu_id)
 
     # Get export parameters
-    model_path = export_config.checkpoint
     key = experiment_config.encryption_key
     TLTPyTorchCookbook.set_passphrase(key)
 
@@ -923,13 +929,26 @@ def run_export(experiment_config: ExperimentConfig) -> None:
 
     # Set default output filename if checkpoint provided
     if output_file is None:
-        if model_path:
-            split_name = os.path.splitext(model_path)[0]
-            output_file = f"{split_name}.onnx"
-        else:
-            raise ValueError(
-                "onnx_file must be specified when exporting without checkpoint"
+        split_name = os.path.splitext(model_path)[0]
+        output_file = f"{split_name}.onnx"
+
+    vision_file = None
+    text_file = None
+    if encoder_type == 'combined':
+        if os.path.exists(output_file):
+            raise FileExistsError(
+                f"Output ONNX file already exists: {output_file}"
             )
+    else:
+        base_name = os.path.splitext(output_file)[0]
+        ext = os.path.splitext(output_file)[1]
+        vision_file = f"{base_name}_vision{ext}"
+        text_file = f"{base_name}_text{ext}"
+        for encoder_file in (vision_file, text_file):
+            if os.path.exists(encoder_file):
+                raise FileExistsError(
+                    f"Output ONNX file already exists: {encoder_file}"
+                )
 
     # Create output directory
     output_root = os.path.dirname(os.path.realpath(output_file))
@@ -938,28 +957,19 @@ def run_export(experiment_config: ExperimentConfig) -> None:
 
     device = 'cpu' if on_cpu else 'cuda'
 
-    # Load model from checkpoint or build from HuggingFace pretrained weights
-    if model_path:
-        logging.info(f"Loading model from checkpoint: {model_path}")
-        # Preservation regularization is training-only; skip the frozen-teacher
-        # deep copy so export does not carry a second copy of the backbone.
-        restore_config = copy.deepcopy(experiment_config)
-        restore_reg = getattr(restore_config, "regularization", None)
-        if restore_reg is not None and getattr(restore_reg, "enabled", False):
-            restore_reg.enabled = False
-        # pylint: disable=no-value-for-parameter
-        pl_model = VideoCLIPPlModel.load_from_checkpoint(
-            model_path,
-            map_location=device,
-            experiment_spec=restore_config
-        )
-    else:
-        logging.info(
-            f"No checkpoint provided. Building model from HuggingFace "
-            f"pretrained weights: {experiment_config.model.type}"
-        )
-        pl_model = VideoCLIPPlModel(experiment_config)
-        pl_model = pl_model.to(device)
+    logging.info(f"Loading model from checkpoint: {model_path}")
+    # Preservation regularization is training-only; skip the frozen-teacher
+    # deep copy so export does not carry a second copy of the backbone.
+    restore_config = copy.deepcopy(experiment_config)
+    restore_reg = getattr(restore_config, "regularization", None)
+    if restore_reg is not None and getattr(restore_reg, "enabled", False):
+        restore_reg.enabled = False
+    # pylint: disable=no-value-for-parameter
+    pl_model = VideoCLIPPlModel.load_from_checkpoint(
+        model_path,
+        map_location=device,
+        experiment_spec=restore_config
+    )
 
     # Match the vision dummy-input resolution to the model when the user left
     # the export defaults untouched. IV2-CLIP uses image_size=224 while the
@@ -993,10 +1003,6 @@ def run_export(experiment_config: ExperimentConfig) -> None:
 
     # Export based on encoder_type
     if encoder_type == 'combined':
-        if os.path.exists(output_file):
-            raise FileExistsError(
-                f"Output ONNX file already exists: {output_file}"
-            )
         logging.info("Exporting combined (vision + text) encoder")
         export_combined_encoder(
             pl_model,
@@ -1007,21 +1013,6 @@ def run_export(experiment_config: ExperimentConfig) -> None:
         )
 
     else:  # separate
-        base_name = os.path.splitext(output_file)[0]
-        ext = os.path.splitext(output_file)[1]
-
-        vision_file = f"{base_name}_vision{ext}"
-        text_file = f"{base_name}_text{ext}"
-
-        if os.path.exists(vision_file):
-            raise FileExistsError(
-                f"Output ONNX file already exists: {vision_file}"
-            )
-        if os.path.exists(text_file):
-            raise FileExistsError(
-                f"Output ONNX file already exists: {text_file}"
-            )
-
         logging.info(
             "Exporting vision and text encoders as separate ONNX files"
         )

--- a/nvidia_tao_pytorch/multimodal/video_clip/scripts/export.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/scripts/export.py
@@ -18,6 +18,7 @@
 
 import copy
 import os
+import shutil
 from typing import Optional, Tuple
 
 import numpy as np
@@ -886,7 +887,48 @@ def export_combined_encoder(
         return tmp_onnx_file
 
 
-def run_export(experiment_config: ExperimentConfig) -> None:
+def _expected_export_artifacts(export_config):
+    """Return the explicit files and directories an export may create."""
+    model_path = export_config.checkpoint
+    if not model_path:
+        return set()
+
+    output_file = export_config.onnx_file
+    if output_file is None:
+        output_file = f"{os.path.splitext(model_path)[0]}.onnx"
+
+    encoder_type = getattr(export_config, 'encoder_type', 'combined')
+    if encoder_type not in VALID_ENCODER_TYPES:
+        return set()
+
+    base_name, ext = os.path.splitext(output_file)
+    if encoder_type == 'combined':
+        encoder_files = (output_file,)
+    else:
+        encoder_files = (
+            f"{base_name}_vision{ext}",
+            f"{base_name}_text{ext}",
+        )
+
+    artifacts = {
+        f"{base_name}_config.yaml",
+        f"{base_name}_tokenizer",
+    }
+    for encoder_file in encoder_files:
+        artifacts.add(encoder_file)
+        onnx_file = (
+            f"{os.path.splitext(encoder_file)[0]}.onnx"
+            if encoder_file.endswith('.etlt') else encoder_file
+        )
+        artifacts.update({
+            onnx_file,
+            f"{onnx_file}.data",
+            f"{os.path.splitext(onnx_file)[0]}_weights.bin",
+        })
+    return artifacts
+
+
+def _run_export_impl(experiment_config: ExperimentConfig) -> None:
     """Run ONNX export for CLIP model.
 
     The encoder_type config option controls the export mode:
@@ -1060,6 +1102,30 @@ def run_export(experiment_config: ExperimentConfig) -> None:
         adaptor_name=getattr(experiment_config.model, 'adaptor_name', None),
     )
     logging.info(f"Tokenizer saved to {tokenizer_dir}")
+
+
+def run_export(experiment_config: ExperimentConfig) -> None:
+    """Run export and remove artifacts created by a failed attempt."""
+    artifacts = _expected_export_artifacts(experiment_config.export)
+    existing_artifacts = {
+        path for path in artifacts if os.path.lexists(path)
+    }
+    try:
+        _run_export_impl(experiment_config)
+    except Exception:
+        for path in artifacts - existing_artifacts:
+            try:
+                if os.path.isdir(path) and not os.path.islink(path):
+                    shutil.rmtree(path)
+                elif os.path.lexists(path):
+                    os.remove(path)
+            except OSError as cleanup_error:
+                logging.warning(
+                    "Failed to clean partial export artifact %s: %s",
+                    path,
+                    cleanup_error,
+                )
+        raise
 
 
 spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/nvidia_tao_pytorch/multimodal/video_clip/utils/internvideo2_assets.py
+++ b/nvidia_tao_pytorch/multimodal/video_clip/utils/internvideo2_assets.py
@@ -132,9 +132,18 @@ def _hf_download(repo_id, filename, label):
         )
     # No cache_dir/local_files_only: rely on ambient HF_HOME; cache-aware
     # (downloads only if missing). Token via the standard HF_TOKEN env if set.
-    resolved = hf_hub_download(
-        repo_id=repo_id, filename=filename, revision=revision,
-    )
+    try:
+        resolved = hf_hub_download(
+            repo_id=repo_id, filename=filename, revision=revision,
+        )
+    except (OSError, ValueError) as exc:
+        source_revision = revision or "main"
+        raise RuntimeError(
+            f"Hugging Face download failed for {label}: repo={repo_id}, "
+            f"file={filename}, revision={source_revision}. Stop and report "
+            "this error, or set the corresponding model field to an existing "
+            "local checkpoint before retrying."
+        ) from exc
     return _require_file(resolved, label)
 
 

--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -3,8 +3,8 @@
 # FROM nvcr.io/nvstaging/tao/tao_pytorch_base_image@sha256:23c2385c3d9232cf0e8b4d37d13fc7e9c9db8fece5c0f6475e5f7924dc6ac06a
 # Select base image based on architecture
 ARG TARGETARCH # provided by Docker if using BuildKit. Else pass in explicitly.
-ARG X86_DIGEST=0dda18f23cbdb62177afa1805a900d29fa4feb7e81feaecf0208495e1db4ccbe
-ARG ARM64_DIGEST=0edf38a0afd615dbbe169e96d5f00e7f7e1bbd8818221b0103541f81b61c4327
+ARG X86_DIGEST=224a161014b5c7ac864e5d1055600d4d27c08a2e23e89bc6e5102a474d2ffae2
+ARG ARM64_DIGEST=2e095fb1db53458140769418dcd3c0cae46042a8554a94b5cb0bea86ec8811c0
 
 FROM nvcr.io/nvstaging/tao/tao_pytorch_base_image@sha256:${ARM64_DIGEST} AS base-arm64
 FROM nvcr.io/nvstaging/tao/tao_pytorch_base_image@sha256:${X86_DIGEST} AS base-amd64
@@ -69,6 +69,7 @@ ENV RUN_CLI=0
 # layers and overlay2 caps a container at 128, so every extra RUN/COPY layer counts;
 # collapsing these three steps into one keeps the release image buildable.
 RUN cd /opt/nvidia/wheels && ls ./*.whl | xargs -I'{}' python -m pip install '{}' && rm -f *.whl && \
+    python -c 'import importlib.util; from importlib.metadata import version; import av, onnxscript; assert version("av") == "17.1.0"; assert version("onnxscript") == "0.7.1"; assert importlib.util.find_spec("decord") is None; print(f"FC video dependencies: av={av.__version__}, onnxscript={onnxscript.__version__}, decord=absent")' && \
     ARCH_LIB_PATH="/usr/lib/$(uname -m)-linux-gnu" && \
     sed -i "s|export LD_LIBRARY_PATH=${ARCH_LIB_PATH}:\${LD_LIBRARY_PATH}|export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:${ARCH_LIB_PATH}|g" /etc/bash.bashrc && \
     { find / -type d -name ".git" -exec rm -rf {} + 2>/dev/null; \

--- a/tests/core/test_default_specs.py
+++ b/tests/core/test_default_specs.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for default experiment specification generation."""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+from nvidia_tao_pytorch.core.utils import default_specs
+
+
+@dataclass
+class _ExperimentConfig:
+    """Minimal experiment configuration for generation tests."""
+
+    value: int = 1
+
+
+@pytest.fixture
+def _mock_config_module(monkeypatch):
+    """Replace module discovery and import with a small local schema."""
+    module = SimpleNamespace(
+        __name__="nvidia_tao_pytorch.config.test.default_config",
+        ExperimentConfig=_ExperimentConfig,
+    )
+    monkeypatch.setattr(default_specs, "get_supported_modules", lambda: ["test"])
+    monkeypatch.setattr(default_specs, "import_module_from_path", lambda _: module)
+
+
+def test_default_specs_prints_yaml_without_results_dir(_mock_config_module, capsys):
+    """Omitting results_dir prints the generated specification to stdout."""
+    default_specs.main(SimpleNamespace(module_name="test", results_dir=None))
+
+    output = capsys.readouterr().out
+    assert OmegaConf.create(output) == {"value": 1}
+
+
+def test_default_specs_writes_yaml_with_results_dir(_mock_config_module, tmp_path):
+    """An explicit results_dir preserves experiment.yaml file output."""
+    output_dir = tmp_path / "specs"
+    default_specs.main(SimpleNamespace(
+        module_name="test",
+        results_dir=str(output_dir),
+    ))
+
+    output_path = output_dir / "experiment.yaml"
+    assert OmegaConf.load(output_path) == {"value": 1}

--- a/tests/multimodal_unit_test/video_clip/test_config.py
+++ b/tests/multimodal_unit_test/video_clip/test_config.py
@@ -70,6 +70,12 @@ class TestVideoCLIPConfigSchema:
         assert issubclass(VideoCLIPEvaluateConfig, VideoCLIPRunConfig)
         assert issubclass(VideoCLIPInferenceConfig, VideoCLIPRunConfig)
 
+    @pytest.mark.parametrize("task", ["evaluate", "inference", "export"])
+    def test_checkpoint_is_required(self, task):
+        """Every checkpoint-backed task exposes a mandatory schema field."""
+        cfg = OmegaConf.structured(VideoCLIPExperimentConfig())
+        assert OmegaConf.is_missing(cfg[task], "checkpoint")
+
     def test_dataset_has_metrics_not_evaluation(self):
         """dataset.evaluation was renamed to dataset.metrics."""
         cfg = OmegaConf.structured(VideoCLIPExperimentConfig())

--- a/tests/multimodal_unit_test/video_clip/test_internvideo2_assets.py
+++ b/tests/multimodal_unit_test/video_clip/test_internvideo2_assets.py
@@ -153,6 +153,38 @@ class TestInternVideo2Assets:
         assert seen, "expected hf_hub_download to be called"
         assert all(revision is None for _, revision in seen)
 
+    def test_hf_download_failure_reports_component_and_source(self, monkeypatch):
+        """HF failures should stop with enough context to report or retry."""
+        download_error = ConnectionError("network unavailable")
+
+        def fake_hf_hub_download(repo_id, filename, revision=None):
+            del repo_id, filename, revision
+            raise download_error
+
+        monkeypatch.setattr(
+            "huggingface_hub.hf_hub_download", fake_hf_hub_download
+        )
+
+        with pytest.raises(RuntimeError) as error:
+            resolve_internvideo2_l14_assets(SimpleNamespace(
+                vision_encoder=None,
+                text_encoder="apple/MobileCLIP-B-LT",
+                clip_head=None,
+                internvideo2clip_hf_id=DEFAULT_INTERNVIDEO2CLIP_HF_ID,
+            ))
+
+        message = str(error.value)
+        assert (
+            "Hugging Face download failed for InternVideo2 vision encoder"
+            in message
+        )
+        assert DEFAULT_INTERNVIDEO2CLIP_HF_ID in message
+        assert "stage1/L14/L14_dist_1B_stage2/pytorch_model.bin" in message
+        assert DEFAULT_INTERNVIDEO2CLIP_REVISION in message
+        assert "Stop and report" in message
+        assert "existing local checkpoint" in message
+        assert error.value.__cause__ is download_error
+
     def test_all_null_sources_return_architecture_only_assets(self):
         """All-null is the explicit random/architecture-only configuration."""
         assets = resolve_internvideo2_l14_assets(SimpleNamespace(

--- a/tests/multimodal_unit_test/video_clip/test_model_type_guard.py
+++ b/tests/multimodal_unit_test/video_clip/test_model_type_guard.py
@@ -44,6 +44,7 @@ def _experiment_config(model_type):
         ),
         dataset=SimpleNamespace(augmentation=None),
         train=SimpleNamespace(loss_type="internvideo2_vtc"),
+        peft=SimpleNamespace(enabled=False),
     )
 
 
@@ -75,3 +76,22 @@ class TestModelTypeGuard:
         built = build_model(_experiment_config("internvideo2-clip-l14"))
         assert built.model == "model"
         assert built.tokenizer == "tokenizer"
+
+    def test_peft_suppresses_pre_injection_parameter_report(self, monkeypatch):
+        """PEFT runs must not log counts before LoRA modules are injected."""
+        builder_kwargs = {}
+
+        def _build(**kwargs):
+            builder_kwargs.update(kwargs)
+            return "model", "preprocess_train", "preprocess_val", "tokenizer"
+
+        monkeypatch.setattr(
+            video_clip_module,
+            "build_internvideo2clip_model",
+            _build,
+        )
+        config = _experiment_config("internvideo2-clip-l14")
+        config.peft.enabled = True
+        build_model(config)
+
+        assert builder_kwargs["log_parameters"] is False

--- a/tests/multimodal_unit_test/video_clip/test_scripts.py
+++ b/tests/multimodal_unit_test/video_clip/test_scripts.py
@@ -30,6 +30,7 @@ import torch
 import torch.nn as nn
 
 from nvidia_tao_pytorch.multimodal.video_clip.model import pl_video_clip_model
+from nvidia_tao_pytorch.multimodal.video_clip.scripts import export as export_module
 from nvidia_tao_pytorch.multimodal.video_clip.scripts.inference import (
     _dedup_preserve_order,
     _embeddings_cache_ok,
@@ -38,6 +39,7 @@ from nvidia_tao_pytorch.multimodal.video_clip.scripts.inference import (
 from nvidia_tao_pytorch.multimodal.video_clip.scripts.export import (
     VALID_ENCODER_TYPES,
     _get_video_export_num_frames,
+    run_export,
 )
 from nvidia_tao_pytorch.multimodal.video_clip.utils.embedding_io import (
     read_embeddings_h5,
@@ -321,3 +323,50 @@ class TestExportHelpers:
 
         m.num_frames = 0  # non-positive -> None
         assert _get_video_export_num_frames(m) is None
+
+    def test_export_requires_trained_checkpoint(self):
+        """A null checkpoint fails before export setup begins."""
+        experiment = SimpleNamespace(
+            export=SimpleNamespace(checkpoint=None),
+        )
+
+        with pytest.raises(ValueError, match="trained checkpoint is required"):
+            run_export(experiment)
+
+    @pytest.mark.parametrize(
+        ("encoder_type", "existing_suffix"),
+        [
+            ("combined", ".onnx"),
+            ("separate", "_vision.onnx"),
+            ("separate", "_text.onnx"),
+        ],
+    )
+    def test_existing_output_fails_before_model_load(
+        self,
+        encoder_type,
+        existing_suffix,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Existing combined or separate outputs are rejected immediately."""
+        output_file = tmp_path / "model.onnx"
+        existing_file = tmp_path / f"model{existing_suffix}"
+        existing_file.touch()
+        experiment = SimpleNamespace(
+            encryption_key="",
+            export=SimpleNamespace(
+                checkpoint="model.ckpt",
+                gpu_id=0,
+                on_cpu=True,
+                onnx_file=str(output_file),
+                encoder_type=encoder_type,
+            ),
+        )
+        monkeypatch.setattr(
+            export_module.VideoCLIPPlModel,
+            "load_from_checkpoint",
+            lambda *args, **kwargs: pytest.fail("model was loaded"),
+        )
+
+        with pytest.raises(FileExistsError, match=str(existing_file)):
+            run_export(experiment)

--- a/tests/multimodal_unit_test/video_clip/test_scripts.py
+++ b/tests/multimodal_unit_test/video_clip/test_scripts.py
@@ -370,3 +370,91 @@ class TestExportHelpers:
 
         with pytest.raises(FileExistsError, match=str(existing_file)):
             run_export(experiment)
+
+    @pytest.mark.parametrize(
+        ("encoder_type", "partial_suffixes"),
+        [
+            (
+                "combined",
+                (".onnx", ".onnx.data", "_tokenizer"),
+            ),
+            (
+                "separate",
+                (
+                    "_vision.onnx",
+                    "_vision_weights.bin",
+                    "_text.onnx",
+                    "_config.yaml",
+                    "_tokenizer",
+                ),
+            ),
+        ],
+    )
+    def test_failed_export_removes_only_new_expected_artifacts(
+        self,
+        encoder_type,
+        partial_suffixes,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A failed export is retryable without sweeping same-prefix files."""
+        output_file = tmp_path / "model.onnx"
+        unrelated_file = tmp_path / "model.notes"
+        unrelated_file.write_text("keep", encoding="utf-8")
+        experiment = SimpleNamespace(
+            export=SimpleNamespace(
+                checkpoint="model.ckpt",
+                onnx_file=str(output_file),
+                encoder_type=encoder_type,
+            ),
+        )
+
+        def _fail_after_writes(_experiment):
+            for suffix in partial_suffixes:
+                artifact = tmp_path / f"model{suffix}"
+                if suffix == "_tokenizer":
+                    artifact.mkdir()
+                    (artifact / "tokenizer.json").write_text(
+                        "partial", encoding="utf-8"
+                    )
+                else:
+                    artifact.write_text("partial", encoding="utf-8")
+            raise RuntimeError("parity mismatch")
+
+        monkeypatch.setattr(export_module, "_run_export_impl", _fail_after_writes)
+
+        with pytest.raises(RuntimeError, match="parity mismatch"):
+            run_export(experiment)
+
+        assert unrelated_file.read_text(encoding="utf-8") == "keep"
+        for suffix in partial_suffixes:
+            assert not (tmp_path / f"model{suffix}").exists()
+
+    def test_failed_export_preserves_preexisting_expected_artifact(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Rollback never removes an expected artifact it did not create."""
+        output_file = tmp_path / "model.onnx"
+        config_file = tmp_path / "model_config.yaml"
+        config_file.write_text("existing", encoding="utf-8")
+        experiment = SimpleNamespace(
+            export=SimpleNamespace(
+                checkpoint="model.ckpt",
+                onnx_file=str(output_file),
+                encoder_type="combined",
+            ),
+        )
+
+        def _fail_after_write(_experiment):
+            output_file.write_text("partial", encoding="utf-8")
+            raise RuntimeError("export failed")
+
+        monkeypatch.setattr(export_module, "_run_export_impl", _fail_after_write)
+
+        with pytest.raises(RuntimeError, match="export failed"):
+            run_export(experiment)
+
+        assert not output_file.exists()
+        assert config_file.read_text(encoding="utf-8") == "existing"

--- a/tests/multimodal_unit_test/video_clip/test_tokenizers.py
+++ b/tests/multimodal_unit_test/video_clip/test_tokenizers.py
@@ -53,4 +53,6 @@ def test_save_openclip_tokenizer_offline_preserves_token_ids(
 
     torch.testing.assert_close(restored_ids, source_tokenizer(texts))
     assert restored_tokenizer.pad_token_id == 0
+    assert restored_tokenizer.convert_ids_to_tokens(0) == "<pad>"
+    assert restored_tokenizer.decode([0], skip_special_tokens=False) == "<pad>"
     assert restored_tokenizer.model_max_length == source_tokenizer.context_length

--- a/tests/multimodal_unit_test/video_clip/test_tokenizers.py
+++ b/tests/multimodal_unit_test/video_clip/test_tokenizers.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Video-CLIP tokenizer serialization."""
+
+from types import SimpleNamespace
+
+import open_clip
+import torch
+
+from nvidia_tao_pytorch.multimodal.video_clip.model import tokenizers
+
+
+def test_save_openclip_tokenizer_offline_preserves_token_ids(
+    tmp_path,
+    monkeypatch,
+):
+    """Loaded OpenCLIP BPE assets save offline with exact token-ID parity."""
+    source_tokenizer = open_clip.get_tokenizer("ViT-B-16")
+    output_dir = tmp_path / "tokenizer"
+    texts = [
+        "hello world",
+        "Capitalization, punctuation!",
+        "",
+        "café — test",
+    ]
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    with monkeypatch.context() as context:
+        def _unexpected_download(*args, **kwargs):
+            raise AssertionError("unexpected Hugging Face download")
+
+        context.setattr(
+            tokenizers.AutoTokenizer,
+            "from_pretrained",
+            _unexpected_download,
+        )
+        tokenizers.save_tokenizer(
+            SimpleNamespace(_tokenizer=source_tokenizer),
+            str(output_dir),
+            model_type="internvideo2-clip-l14",
+        )
+
+    restored_tokenizer = tokenizers.load_tokenizer(str(output_dir))
+    restored_ids = restored_tokenizer(
+        texts,
+        padding="max_length",
+        truncation=True,
+        max_length=source_tokenizer.context_length,
+        return_tensors="pt",
+    ).input_ids
+
+    torch.testing.assert_close(restored_ids, source_tokenizer(texts))
+    assert restored_tokenizer.pad_token_id == 0
+    assert restored_tokenizer.model_max_length == source_tokenizer.context_length


### PR DESCRIPTION
## What

Fix the Video-CLIP FC dependencies and five related Python workflows:

- Propagate PyAV and ONNXScript into the FC/release image.
- Report Hugging Face weight download failures clearly.
- Correct PEFT trainable-parameter reporting.
- Print default specs without requiring an output directory.
- Validate export inputs before loading the model.
- Save the OpenCLIP tokenizer for offline export.

## Problem

The release build still used the previous FC base, so the resulting image could omit PyAV and use the wrong ONNXScript version. PyAV was also present in two installation paths.

Several Video-CLIP error and export paths produced misleading output or failed too late.

## Solution

- Pin the corrected FC base digests in the development and release builds.
- Preserve the source-built `av==17.1.0` installation and remove its duplicate pip installation path.
- Assert `av==17.1.0`, `onnxscript==0.7.1`, and the absence of Decord in the release image.
- Add focused error reporting, parameter accounting, validation, and offline-tokenizer fixes.

## Testing

- Source tree: 60 passed, 1 expected skip.
- Installed release wheel: 60 passed, 1 expected skip.
- Verified all seven changed Python files in the wheel match branch HEAD.
- Verified real VP9 WebM decoding through TAO's PyAV backend.
- Verified no bundled `av.libs` and no Decord installation.
- Verified all 121 FC-base layers are preserved in the AMD64 release.
- Pylint: 10.00/10.
- Pydocstyle, flake8, license, DCO, and diff checks passed.

Validated release candidate:

`nvcr.io/nvstaging/tao/tao-toolkit-pyt@sha256:faeb58559e1d87afd16453580999c178feb345f9dc87e35b8f40098e9604dd09`

The earlier `py3-05` candidate is superseded because it lacks PyAV.

## Review follow-up

- Export intentionally requires a trained TAO checkpoint; checkpoint-less Hugging Face export is not a supported Video-CLIP workflow. Export, evaluate, and inference now expose mandatory checkpoint schema fields; the open companion NVIDIA-TAO/tao-core#30 still needs the same schema update before it merges.
- Failed exports now remove only newly created, explicitly expected artifacts, so retries do not require manual cleanup and unrelated same-prefix files remain untouched.
- OpenCLIP token ID 0 intentionally decodes as `<pad>` in the saved Hugging Face tokenizer while encoding parity is preserved.
- Independent real-checkpoint validation compared separate PyTorch and ONNX vision/text outputs on two random videos and two tokenized prompts: all outputs passed at `rtol=1e-3`, `atol=1e-3`; worst absolute error `4.62e-05`, minimum embedding cosine `0.9999999587`.

## Tracking

- NVBug 6664626
- NVBug 6664694
- NVBug 6670447
- NVBug 6670205
- NVBug 6670035
- NVBug 6670031
- NVBug 6670019
- Related: #94
- Overlaps #113 for the Python fixes; this branch additionally includes the FC dependency and HF failure fixes.

## Checklist

- [x] Bugs resolved
- [x] Regression tests added and passing
- [x] AMD64 release image validated
- [x] No Skill Bank changes
