### PR TITLE
[TAO-1796][Feature] [AIRE][closed-source-pr-merged] fix(ci): resolve 1 bug(s) from PR #106 (run 33026366777)

### DIFF
--- a/tests/multimodal_integration_test/clip/test_lora_training.py
+++ b/tests/multimodal_integration_test/clip/test_lora_training.py
@@ -164,10 +164,15 @@ class MockTransformerCLIP(BaseCLIPAdapter):
 # ---------------------------------------------------------------------------
 
 
+def _tower_mode(enabled):
+    """Map a boolean tower selector onto its explicit tower mode."""
+    return 'lora' if enabled else 'frozen'
+
+
 class MockLoRATargetConfig:
-    def __init__(self, enabled=True, target_modules=None,
+    def __init__(self, mode='lora', target_modules=None,
                  num_last_blocks=2, rank=4, alpha=8, dropout=0.0):
-        self.enabled = enabled
+        self.mode = mode
         self.target_modules = target_modules or [
             'q_proj', 'k_proj', 'v_proj', 'out_proj'
         ]
@@ -182,8 +187,10 @@ class MockPEFTConfig:
                  **kwargs):
         self.enabled = enabled
         self.method = 'lora'
-        self.vision = MockLoRATargetConfig(enabled=vision_enabled, **kwargs)
-        self.text = MockLoRATargetConfig(enabled=text_enabled, **kwargs)
+        self.vision = MockLoRATargetConfig(
+            mode=_tower_mode(vision_enabled), **kwargs)
+        self.text = MockLoRATargetConfig(
+            mode=_tower_mode(text_enabled), **kwargs)
 
 
 class MockRegConfig:


### PR DESCRIPTION
## What this fixes

Blossom-CI run [`33026366777`](https://github.com/NVIDIA-TAO/tao-pytorch/actions/runs/33026366777) on **PR #106** failed with **19 test failures**, all raising the same error:

```
E   ValueError: Invalid vision PEFT mode None. Expected one of ['frozen', 'full', 'lora'].
nvidia_tao_pytorch/multimodal/clip/model/lora.py:140: ValueError
```

```
== 19 failed, 2376 passed, 153 skipped, 43524 warnings in 9451.41s (2:37:31) ===
```

This PR targets `feature/clip-lora-dev` (the branch of PR #106) so the fix lands directly on the work under test.

Fixes NVIDIA-TAO/tao-pytorch#115

---

## Bug group g1 — `stale-lora-tower-mode-fixture`

**Failure class:** `test_failure` · **Confidence:** `high` · **Detected via:** `upload_log_scan`

### Root cause

Commit `5601f55` (*"[TAO-1796][Refactor] Finalize CLIP LoRA tower modes"*) completed the migration from the legacy boolean per-tower selector (`enabled`) to an explicit per-tower `mode`, and removed the legacy fallback from `resolve_tower_mode()` (`nvidia_tao_pytorch/multimodal/clip/model/lora.py:125-144`):

```python
# before (removed in 5601f55)
mode = _config_value(tower_config, 'mode', LEGACY_TOWER_MODE)
enabled = _config_value(tower_config, 'enabled')
if mode in (None, '???', LEGACY_TOWER_MODE):
    return 'lora' if enabled else 'frozen'

# after (current) — an explicit, valid mode is now mandatory
mode = _config_value(tower_config, 'mode')
if mode not in VALID_TOWER_MODES:
    raise ValueError(...)
```

That commit migrated the **unit-test** fixtures (`tests/multimodal_unit_test/clip/test_lora.py`, `tests/multimodal_unit_test/video_clip/test_lora_peft.py`) — deleting the `_legacy_tower()` helper and asserting tower configs no longer expose `enabled` — but **the integration-test fixture was not migrated alongside them**.

`tests/multimodal_integration_test/clip/test_lora_training.py:167` still built tower configs with the removed selector:

```python
class MockLoRATargetConfig:
    def __init__(self, enabled=True, ...):
        self.enabled = enabled          # <-- `mode` never set
```

So `_config_value(tower_config, 'mode')` returned `None`, which is not in `{'frozen','full','lora'}`, and every test reaching `inject_lora()` raised `ValueError` — 19 tests across `TestLoRATrainingLoop`, `TestPreservationLossTraining`, `TestLoRAMergeExport`, `TestLoRACheckpoint`, `TestLoRAWithDataloader`, and `TestLoRAExport`.

This is a **stale test fixture**, not a production regression: the strict-mode behavior is intentional and matches the public schema `CLIPLoRATargetConfig` (`nvidia_tao_pytorch/config/clip/default_config.py:113`), which declares `mode: str = "frozen"` and has no `enabled` field.

### What this change does

Migrates the integration-test fixture to the explicit tower-mode API, mirroring the canonical schema:

- **`MockLoRATargetConfig`** now carries `mode` (`'frozen'|'full'|'lora'`) instead of `enabled`.
- **`MockPEFTConfig`** translates its `vision_enabled` / `text_enabled` selectors into explicit modes via a small `_tower_mode()` helper — `True -> 'lora'`, `False -> 'frozen'`, exactly the legacy semantics `resolve_tower_mode()` used to apply.

```python
def _tower_mode(enabled):
    """Map a boolean tower selector onto its explicit tower mode."""
    return 'lora' if enabled else 'frozen'
```

**Deliberately minimal:** keeping the boolean `vision_enabled`/`text_enabled` kwargs on `MockPEFTConfig` means all ~19 existing call sites — including the boolean-parametrized ones at lines 912 and 994 — keep working unchanged, with no test semantics altered. Only the fixture moves to the new API.

`MockPEFTConfig.enabled` is retained on purpose: the top-level `CLIPPEFTConfig` still has an `enabled` field; only the *tower* configs dropped it.

### Files changed

| File | Change |
|---|---|
| `tests/multimodal_integration_test/clip/test_lora_training.py` | Migrate `MockLoRATargetConfig` / `MockPEFTConfig` to the explicit tower-mode API (+11 / -4) |

No production code is modified.

---

## Known issues without a fix

None — every failure in run `33026366777` belongs to group `g1` and is addressed here.

---

## Verification

- `python -m py_compile` on the patched test file: **passes**.
- The real `resolve_tower_mode()` / `_config_value()` implementations were executed against the migrated fixture for all four `vision_enabled`/`text_enabled` combinations used in the file — all resolve to valid tower modes with no `ValueError`:

  | `vision_enabled` | `text_enabled` | resolved vision | resolved text |
  |---|---|---|---|
  | `True` | `False` | `lora` | `frozen` |
  | `True` | `True` | `lora` | `lora` |
  | `False` | `False` | `frozen` | `frozen` |
  | `False` | `True` | `frozen` | `lora` |

- Full verification runs through Blossom-CI on this PR.

---

## AIRE Self-Check
- ✅ **Scope of change:** AIRE modified only files inside this repository and pushed them as a normal git commit. ✅
- ✅ **Secret handling:** Credentials are scrubbed from all logs and never printed. ✅

---

*Opened automatically by **AIRE** from Blossom-CI run `33026366777`.*

Signed-off-by: svc-bcs-agent <svc-bcs-agent@nvidia.com>

<!-- AIRE-META
source_pr: 106
source_head_sha: 5601f5564f0c941332ca865f5b2aac078bc73c6d
source_repo: NVIDIA-TAO/tao-pytorch
dest_repo: NVIDIA-TAO/tao-pytorch
fix_branch: fix/tao-pytorch-5601f55
run_id: 33026366777
issue: 115
-->
