### PR TITLE
[Bugfix] Patch av==17.1.0 into release image (base image missing PyAV)

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -69,6 +69,7 @@ ENV RUN_CLI=0
 # layers and overlay2 caps a container at 128, so every extra RUN/COPY layer counts;
 # collapsing these three steps into one keeps the release image buildable.
 RUN cd /opt/nvidia/wheels && ls ./*.whl | xargs -I'{}' python -m pip install '{}' && rm -f *.whl && \
+    python -m pip install 'av==17.1.0' 'onnxscript==0.7.1' && \
     python -c 'import importlib.util; from importlib.metadata import version; import av, onnxscript; assert version("av") == "17.1.0"; assert version("onnxscript") == "0.7.1"; assert importlib.util.find_spec("decord") is None; print(f"FC video dependencies: av={av.__version__}, onnxscript={onnxscript.__version__}, decord=absent")' && \
     ARCH_LIB_PATH="/usr/lib/$(uname -m)-linux-gnu" && \
     sed -i "s|export LD_LIBRARY_PATH=${ARCH_LIB_PATH}:\${LD_LIBRARY_PATH}|export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:${ARCH_LIB_PATH}|g" /etc/bash.bashrc && \


### PR DESCRIPTION
## Problem
`tao-pytorch-OSS-release` nightly builds **57–59 fail** (56 was green) at stage-2 step 7/7:
```
Successfully installed nvidia-tao-pytorch-…
ModuleNotFoundError: No module named 'av'
```
A new *FC video dependencies* contract (`import av, onnxscript; assert version("av")=="17.1.0"`) was added after build 56, but `tao_pytorch_base_image` no longer ships `av`, so the assert fails on **both x86 (#786) and arm64 (#507)**. The 7.2.0 release rebuild would fail identically (same Dockerfile + base).

## Fix
Install `av==17.1.0` (and pin `onnxscript==0.7.1` defensively) from the official PyPI wheels **inside the existing wheels RUN layer**, right before the verification:
- Official **abi3 manylinux_2_28 wheels exist for both x86_64 and aarch64** → no source build.
- Inserted into the existing `RUN` → **no extra layer** (respects the overlay2 128-layer cap noted in the Dockerfile).
- The assert only checks the version (not decoders), and the official wheel bundles ffmpeg with software decoders → satisfies the check and works at runtime.

Release-side patch until the base image ships `av` again (the cleaner long-term fix is to add `av==17.1.0` back to `tao_pytorch_base_image`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)