### PR TITLE
[TAO-1796][Feature] Add PAS partial-negative alignment loss

### DIFF
--- a/nvidia_tao_pytorch/config/clip/default_config.py
+++ b/nvidia_tao_pytorch/config/clip/default_config.py
@@ -606,19 +606,43 @@ class CLIPTrainConfig(TrainConfig):
         default_value="none",
         valid_options=(
             "none,attribute_match_ignore,"
-            "attribute_plus_accessory_match_ignore"
+            "attribute_plus_accessory_match_ignore,"
+            "attribute_match_positive,"
+            "attribute_plus_accessory_match_positive"
         ),
         description=(
             "Optional metadata-based masking mode for SigLIP loss. "
             "'none' keeps existing behavior; 'attribute_match_ignore' ignores "
             "off-diagonal negatives whose attributes match the text query; "
             "'attribute_plus_accessory_match_ignore' additionally requires "
-            "all query accessories to be present in the image. "
+            "all query accessories to be present in the image. The positive "
+            "variants promote compatible off-diagonal pairs to positives and "
+            "currently require exactly one custom source dataset. "
             "Metadata masking supports siglip_loss_dist_impl='local' or "
             "'gather' and requires "
             "include_attribute_metadata=True on the custom training dataset."
         ),
         display_name="SigLIP Loss Mask Mode",
+    )
+    compatible_positive_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        description=(
+            "Weight for metadata-compatible off-diagonal terms when a "
+            "positive SigLIP metadata mode is selected."
+        ),
+        display_name="Compatible Positive Weight",
+    )
+    compatible_positive_normalization: str = STR_FIELD(
+        value="per_pair",
+        default_value="per_pair",
+        valid_options="per_pair,per_query",
+        description=(
+            "Apply compatible_positive_weight to every promoted pair or "
+            "divide it across all promoted images for each text query."
+        ),
+        display_name="Compatible Positive Normalization",
     )
     triplet_loss_weight: float = FLOAT_FIELD(
         value=0.0,
@@ -636,6 +660,38 @@ class CLIPTrainConfig(TrainConfig):
         valid_min=0.0,
         description="Margin for auxiliary batch-hard image-text triplet loss.",
         display_name="Triplet Margin",
+    )
+    pa_loss_weight: float = FLOAT_FIELD(
+        value=0.0,
+        default_value=0.0,
+        valid_min=0.0,
+        description=(
+            "Weight for the Partial-negative Alignment auxiliary loss. "
+            "Set to 0 to disable."
+        ),
+        display_name="PA Loss Weight",
+    )
+    pa_margin: float = FLOAT_FIELD(
+        value=0.2,
+        default_value=0.2,
+        valid_min=0.0,
+        description="Margin for Partial-negative Alignment loss.",
+        display_name="PA Margin",
+    )
+    pa_inverse_temperature: float = FLOAT_FIELD(
+        value=10.0,
+        default_value=10.0,
+        valid_min=0.000001,
+        description="Inverse temperature (1/tau) for PA hard-negative mining.",
+        display_name="PA Inverse Temperature",
+    )
+    pa_top_ratio: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.000001,
+        valid_max=1.0,
+        description="Fraction of highest-similarity valid negatives used by PA.",
+        display_name="PA Top Negative Ratio",
     )
 
     precision: str = STR_FIELD(

--- a/nvidia_tao_pytorch/multimodal/clip/experiment_specs/experiment_spec.yaml
+++ b/nvidia_tao_pytorch/multimodal/clip/experiment_specs/experiment_spec.yaml
@@ -10,10 +10,17 @@ train:
   pretrained_model_path: null
   loss_type: siglip  # siglip or clip
   siglip_loss_dist_impl: gather  # metadata masking supports local or gather
-  # none, attribute_match_ignore, or attribute_plus_accessory_match_ignore
+  # none, attribute_match_ignore, attribute_plus_accessory_match_ignore,
+  # attribute_match_positive, or attribute_plus_accessory_match_positive
   siglip_loss_mask_mode: none
+  compatible_positive_weight: 1.0
+  compatible_positive_normalization: per_pair  # per_pair or per_query
   triplet_loss_weight: 0.0  # set > 0 to enable triplet loss
   triplet_margin: 0.2
+  pa_loss_weight: 0.0  # set > 0 to enable Partial-negative Alignment
+  pa_margin: 0.2
+  pa_inverse_temperature: 10.0
+  pa_top_ratio: 0.5
   optim:
     optimizer_type: adamw  # adamw, lamb, or sgd
     vision_lr: 1e-4

--- a/nvidia_tao_pytorch/multimodal/clip/experiment_specs/pas_v3_1/PA_REPRODUCTION.md
+++ b/nvidia_tao_pytorch/multimodal/clip/experiment_specs/pas_v3_1/PA_REPRODUCTION.md
@@ -1,0 +1,59 @@
+# PAS V3.1.1 partial-negative alignment reproduction
+
+Use `experiment_siglip2_pas_v3_1_dual_tower_lora_pa.yaml` to reproduce the
+fixed SigLIP2-256 + standard LoRA + partial-negative alignment (PA) run. This
+profile does not use SigLIP2-384, RandLoRA, AutoML, reranking, or query
+expansion.
+
+PA here means only the partial-negative component from Song et al., “Dual
+alignment: Partial negative and soft-label alignment for text-to-image person
+retrieval,” Information Fusion 127 (2026), DOI
+`10.1016/j.inffus.2025.103644`. The soft-label alignment component is not
+implemented, so this code must not be described as the paper's full method.
+
+## Data contract
+
+Mount the balanced PAS V3.1.1 derived dataset at `/workspace/data/pas`, or
+change all data paths in the spec together. The directory must contain:
+
+- `images/`
+- `captions/`
+- `train_list.txt` and `train_pairs.json`
+- `val_list.txt` and `val_pairs.json`
+- `attribute_vocab.json` and `accessory_vocab.json`
+
+The fixed profile uses `val_list.txt` for model selection and
+`scalar_plus_accessories` for both validation and evaluation. Do not select a
+checkpoint using the held-out test split.
+
+## Run
+
+Set a new, empty `results_dir` in a copy of the spec, then run:
+
+```bash
+clip train \
+  -e /path/to/experiment_siglip2_pas_v3_1_dual_tower_lora_pa.yaml
+```
+
+The recorded run used one node with 8 A100 GPUs, fp16, batch size 128 per GPU,
+20 epochs, seed 1234, and selected the maximum `val/pas/overall_mAP` checkpoint.
+Evaluate that checkpoint by setting `evaluate.checkpoint` and a new
+`evaluate.results_dir`, then run:
+
+```bash
+clip evaluate -e /path/to/resolved_pa_evaluate.yaml
+```
+
+## Recorded reference
+
+The historical fixed run selected `model_best_002.pth` and reported:
+
+| Split | mAP | Rank-1 | Rank-5 | Rank-10 |
+|---|---:|---:|---:|---:|
+| Validation | 85.8242% | 83.9294% | 98.1736% | 99.3848% |
+| Test | 83.7930% | 83.0727% | 97.7381% | 99.0349% |
+
+Treat these values as a historical reference, not a unit-test tolerance. A
+fair comparison must preserve the dataset version, train/validation/test
+lists, metadata vocabularies, evaluation ground-truth mode, and checkpoint
+selection rule.

--- a/nvidia_tao_pytorch/multimodal/clip/experiment_specs/pas_v3_1/experiment_siglip2_pas_v3_1_dual_tower_lora_pa.yaml
+++ b/nvidia_tao_pytorch/multimodal/clip/experiment_specs/pas_v3_1/experiment_siglip2_pas_v3_1_dual_tower_lora_pa.yaml
@@ -1,0 +1,113 @@
+# Fixed PAS V3.1.1 SigLIP2-256 + LoRA + Partial-negative Alignment profile.
+#
+# This is the non-AutoML, non-RandLoRA, non-384 configuration that produced
+# the recorded PA run. Replace only the data and results paths. Keep the model,
+# optimizer, LoRA, loss, split, and selection settings unchanged for a
+# reproduction run.
+results_dir: ???
+
+model:
+  type: siglip2-so400m-patch16-256
+  canonicalize_text: false
+  init_logit_scale: null
+  init_logit_bias: null
+
+dataset:
+  seed: 42
+  pin_memory: true
+  train:
+    type: custom
+    balance_query_types: false
+    unique_caption_per_batch: false
+    include_attribute_metadata: true
+    datasets:
+    - image_dir: /workspace/data/pas/images
+      image_list_file: /workspace/data/pas/train_list.txt
+      caption_dir: /workspace/data/pas/captions
+      caption_file_suffix: .txt
+      train_pairs_file: /workspace/data/pas/train_pairs.json
+    batch_size: 128
+    num_workers: 16
+  val:
+    datasets:
+    - image_dir: /workspace/data/pas/images
+      image_list_file: /workspace/data/pas/val_list.txt
+      caption_dir: /workspace/data/pas/captions
+      caption_file_suffix: .txt
+      attribute_pairs_file: /workspace/data/pas/val_pairs.json
+    metadata_match_eval: true
+    metadata_match_mode: scalar_plus_accessories
+    batch_size: 16
+    num_workers: 4
+  augmentation:
+    scale: [0.4, 1.0]
+    color_jitter: [0.8, 0.32, 0.32, 0.32, 0.08]
+    grayscale: 0.2
+
+train:
+  num_epochs: 20
+  num_gpus: 8
+  gpu_ids: [0, 1, 2, 3, 4, 5, 6, 7]
+  num_nodes: 1
+  seed: 1234
+  precision: fp16
+  distributed_strategy: ddp
+  grad_checkpointing: false
+  grad_clip_norm: 1.0
+  checkpoint_interval: 1
+  checkpoint_interval_unit: epoch
+  validation_interval: 1
+  checkpointer:
+    enable_topk: true
+    replace_periodic: true
+    monitor: val/pas/overall_mAP
+    mode: max
+    save_top_k: 1
+    filename: model_best_{epoch:03d}
+    auto_insert_metric_name: false
+  loss_type: siglip
+  siglip_loss_dist_impl: gather
+  siglip_loss_mask_mode: attribute_plus_accessory_match_positive
+  compatible_positive_weight: 0.5
+  compatible_positive_normalization: per_query
+  triplet_loss_weight: 0.0
+  pa_loss_weight: 0.01232533396889774
+  pa_margin: 0.1976525764912367
+  pa_inverse_temperature: 1.9850472486080717
+  pa_top_ratio: 0.07580481977201999
+  optim:
+    optimizer_type: adamw
+    vision_lr: 9.13971426614473e-06
+    text_lr: 2.9080338560326244e-05
+    weight_decay: 0.002249987748436666
+    betas: [0.9, 0.95]
+    eps: 1.0e-06
+    warmup_steps: 0
+    scheduler: cosine
+
+peft:
+  enabled: true
+  method: lora
+  train_logit_calibration: true
+  vision:
+    mode: lora
+    target_modules: [q_proj, k_proj, v_proj, out_proj]
+    num_last_blocks: 24
+    rank: 64
+    alpha: 128
+    dropout: 0.10093809460006695
+  text:
+    mode: lora
+    target_modules: [q_proj, k_proj, v_proj, out_proj]
+    num_last_blocks: 24
+    rank: 64
+    alpha: 128
+    dropout: 0.009450008726896691
+
+regularization:
+  enabled: false
+
+evaluate:
+  checkpoint: ???
+  batch_size: 128
+  pas_ground_truth_mode: scalar_plus_accessories

--- a/nvidia_tao_pytorch/multimodal/clip/loss/masked_siglip_loss.py
+++ b/nvidia_tao_pytorch/multimodal/clip/loss/masked_siglip_loss.py
@@ -27,7 +27,7 @@ from nvidia_tao_pytorch.multimodal.clip.loss.metadata_mask import (
 
 
 class MetadataMaskedSigLipLoss(nn.Module):
-    """SigLIP loss that ignores metadata-compatible off-diagonal negatives.
+    """SigLIP loss with metadata-aware off-diagonal pair handling.
 
     The normalization intentionally mirrors OpenCLIP's SigLipLoss: valid loss
     terms are summed and divided by local image batch size, not by the number
@@ -42,6 +42,9 @@ class MetadataMaskedSigLipLoss(nn.Module):
         world_size: int = 1,
         rank: int = 0,
         accessory_aware: bool = False,
+        compatible_as_positive: bool = False,
+        compatible_positive_weight: float = 1.0,
+        compatible_positive_normalization: str = "per_pair",
     ):
         """Initialize metadata-masked SigLIP loss.
 
@@ -53,6 +56,12 @@ class MetadataMaskedSigLipLoss(nn.Module):
                 inside gathered text chunks.
             accessory_aware: Also require query accessories to be present in
                 an image before ignoring a metadata-compatible off-diagonal.
+            compatible_as_positive: Promote compatible off-diagonal pairs to
+                positives instead of only ignoring them.
+            compatible_positive_weight: Weight assigned to promoted terms.
+            compatible_positive_normalization: ``per_pair`` applies the full
+                weight to every promoted pair. ``per_query`` divides the
+                weight by the global promoted-image count for each text.
         """
         super().__init__()
         if dist_impl not in ("local", "gather"):
@@ -76,6 +85,20 @@ class MetadataMaskedSigLipLoss(nn.Module):
         self.world_size = world_size
         self.rank = rank
         self.accessory_aware = accessory_aware
+        if compatible_positive_weight < 0:
+            raise ValueError(
+                "compatible_positive_weight must be non-negative, got "
+                f"{compatible_positive_weight}."
+            )
+        if compatible_positive_normalization not in ("per_pair", "per_query"):
+            raise ValueError(
+                "compatible_positive_normalization must be 'per_pair' or "
+                f"'per_query', got {compatible_positive_normalization!r}."
+            )
+        self.compatible_as_positive = compatible_as_positive
+        self.compatible_positive_weight = compatible_positive_weight
+        self.compatible_positive_normalization = compatible_positive_normalization
+        self.last_compatible_positive_pairs = torch.tensor(0)
 
     @staticmethod
     def _resolve_positive_text_indices(
@@ -149,21 +172,14 @@ class MetadataMaskedSigLipLoss(nn.Module):
         ] = 1
         return labels
 
-    def get_valid_term_mask(
+    def get_metadata_match_mask(
         self,
         image_attr_values: torch.Tensor,
         text_attr_values: torch.Tensor,
         image_accessory_ids: torch.Tensor | None = None,
         text_accessory_ids: torch.Tensor | None = None,
-        positive_text_indices: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Build a valid-term mask aligned to logits ``[B_image, B_text]``.
-
-        Metadata-compatible off-diagonal pairs are excluded from the loss. In
-        accessory-aware mode, both scalar attributes and required accessories
-        must match before a pair is excluded. Paired positives always remain
-        valid.
-        """
+        """Build metadata compatibility aligned to ``[B_image, B_text]``."""
         metadata_match = build_attribute_match_mask(
             image_attr_values=image_attr_values,
             text_attr_values=text_attr_values,
@@ -179,7 +195,29 @@ class MetadataMaskedSigLipLoss(nn.Module):
                 text_accessory_ids=text_accessory_ids,
             )
             metadata_match = metadata_match & accessory_match
-        metadata_match = metadata_match.T
+        return metadata_match.T
+
+    def get_valid_term_mask(
+        self,
+        image_attr_values: torch.Tensor,
+        text_attr_values: torch.Tensor,
+        image_accessory_ids: torch.Tensor | None = None,
+        text_accessory_ids: torch.Tensor | None = None,
+        positive_text_indices: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Build a valid-term mask aligned to logits ``[B_image, B_text]``.
+
+        Metadata-compatible off-diagonal pairs are excluded from the loss. In
+        accessory-aware mode, both scalar attributes and required accessories
+        must match before a pair is excluded. Paired positives always remain
+        valid.
+        """
+        metadata_match = self.get_metadata_match_mask(
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+            image_accessory_ids=image_accessory_ids,
+            text_accessory_ids=text_accessory_ids,
+        )
         batch_size = image_attr_values.shape[0]
         valid_terms = ~metadata_match
         positive_text_indices = self._resolve_positive_text_indices(
@@ -193,6 +231,41 @@ class MetadataMaskedSigLipLoss(nn.Module):
             positive_text_indices,
         ] = True
         return valid_terms
+
+    def get_targets_and_term_weights(
+        self,
+        labels: torch.Tensor,
+        valid_terms: torch.Tensor,
+        metadata_match: torch.Tensor,
+        positive_text_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Promote compatible pairs and return weighted SigLIP targets."""
+        term_weights = torch.ones_like(labels)
+        promoted = torch.zeros_like(valid_terms)
+        if not self.compatible_as_positive:
+            return labels, valid_terms, term_weights, promoted
+
+        promoted = metadata_match.clone()
+        promoted[
+            torch.arange(labels.shape[0], device=labels.device),
+            positive_text_indices,
+        ] = False
+        labels = labels.clone()
+        valid_terms = valid_terms.clone()
+        labels[promoted] = 1
+        valid_terms[promoted] = True
+
+        if self.compatible_positive_normalization == "per_pair":
+            term_weights[promoted] = self.compatible_positive_weight
+        else:
+            per_query_count = promoted.sum(dim=0, dtype=labels.dtype)
+            if self.dist_impl == "gather" and self.world_size > 1:
+                dist.all_reduce(per_query_count, op=dist.ReduceOp.SUM)
+            normalized = (
+                self.compatible_positive_weight / per_query_count.clamp_min(1)
+            ).expand(labels.shape[0], -1)
+            term_weights[promoted] = normalized[promoted]
+        return labels, valid_terms, term_weights, promoted
 
     def _validate_distributed_context(self) -> None:
         """Ensure configured gather coordinates match the default group."""
@@ -393,8 +466,27 @@ class MetadataMaskedSigLipLoss(nn.Module):
             text_accessory_ids=candidate_text_accessory_ids,
             positive_text_indices=positive_text_indices,
         )
-        loss = -F.logsigmoid(labels * logits).masked_select(valid_terms).sum()
+        metadata_match = self.get_metadata_match_mask(
+            image_attr_values=image_attr_values,
+            text_attr_values=candidate_text_attr_values,
+            image_accessory_ids=image_accessory_ids,
+            text_accessory_ids=candidate_text_accessory_ids,
+        )
+        labels, valid_terms, term_weights, promoted = (
+            self.get_targets_and_term_weights(
+                labels=labels,
+                valid_terms=valid_terms,
+                metadata_match=metadata_match,
+                positive_text_indices=positive_text_indices,
+            )
+        )
+        self.last_compatible_positive_pairs = promoted.sum().detach()
+        loss_terms = -F.logsigmoid(labels * logits) * term_weights
+        loss = loss_terms.masked_select(valid_terms).sum()
         loss = loss / local_batch
         if output_dict:
-            return {"contrastive_loss": loss}
+            output = {"contrastive_loss": loss}
+            if self.compatible_as_positive:
+                output["compatible_positive_pairs"] = promoted.sum()
+            return output
         return loss

--- a/nvidia_tao_pytorch/multimodal/clip/loss/partial_negative_alignment_loss.py
+++ b/nvidia_tao_pytorch/multimodal/clip/loss/partial_negative_alignment_loss.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Partial-negative Alignment loss for image-text retrieval."""
+
+import torch
+import torch.nn.functional as F
+
+
+def partial_negative_alignment_loss(
+    image_features: torch.Tensor,
+    text_features: torch.Tensor,
+    margin: float,
+    inverse_temperature: float,
+    top_ratio: float,
+    compatible_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute symmetric PA loss over the hardest valid negatives.
+
+    The loss follows the partial-negative component of Song et al., *Dual
+    alignment: Partial negative and soft-label alignment for text-to-image
+    person retrieval*. ``compatible_mask`` generalizes identity positives to
+    PAS metadata-compatible pairs; those pairs participate as positives and
+    are never mined as negatives. ``inverse_temperature`` is ``1 / tau`` in
+    the paper's notation.
+    """
+    batch_size = image_features.shape[0]
+    if batch_size != text_features.shape[0]:
+        raise ValueError(
+            "PA requires equal image and text batch sizes, got "
+            f"{batch_size} and {text_features.shape[0]}."
+        )
+    if batch_size < 2:
+        return image_features.new_zeros(())
+    if margin < 0:
+        raise ValueError("PA margin must be non-negative")
+    if inverse_temperature <= 0:
+        raise ValueError("PA inverse temperature must be positive")
+    if not 0.0 < top_ratio <= 1.0:
+        raise ValueError("PA top_ratio must be in (0, 1]")
+
+    image_norm = F.normalize(image_features, dim=-1)
+    text_norm = F.normalize(text_features, dim=-1)
+    similarity = image_norm @ text_norm.mT
+    positive = torch.eye(
+        batch_size, device=similarity.device, dtype=torch.bool
+    )
+    if compatible_mask is not None:
+        compatible_mask = compatible_mask.to(
+            device=similarity.device, dtype=torch.bool
+        )
+        if compatible_mask.shape != similarity.shape:
+            raise ValueError(
+                "compatible_mask must match the PA similarity matrix, got "
+                f"{tuple(compatible_mask.shape)} and {tuple(similarity.shape)}."
+            )
+        positive = positive | compatible_mask
+
+    def _direction(
+        scores: torch.Tensor,
+        positive_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        # Eq. 3: similarity-weighted mean over valid positives.
+        positive_logits = (inverse_temperature * scores).masked_fill(
+            ~positive_mask, float("-inf")
+        )
+        positive_weights = torch.softmax(positive_logits, dim=1)
+        positive_score = (positive_weights * scores).sum(dim=1)
+
+        # Eq. 4--5: retain the largest top-ratio fraction of valid negatives.
+        negative_mask = ~positive_mask
+        negative_counts = negative_mask.sum(dim=1)
+        selected_counts = torch.ceil(
+            negative_counts.float() * top_ratio
+        ).long()
+        max_selected = max(1, int(selected_counts.max().item()))
+        negative_scores = scores.masked_fill(
+            ~negative_mask, float("-inf")
+        )
+        top_negative_scores = torch.topk(
+            negative_scores, k=max_selected, dim=1
+        ).values
+        positions = torch.arange(
+            max_selected, device=scores.device
+        ).unsqueeze(0)
+        top_negative_scores = top_negative_scores.masked_fill(
+            positions >= selected_counts.unsqueeze(1), float("-inf")
+        )
+        smooth_hard_negative = torch.logsumexp(
+            inverse_temperature * top_negative_scores, dim=1
+        ) / inverse_temperature
+        per_anchor = F.relu(
+            margin - positive_score + smooth_hard_negative
+        )
+        # A row with no valid negatives has no PA supervision.
+        return per_anchor.masked_fill(negative_counts == 0, 0.0).mean()
+
+    return 0.5 * (
+        _direction(similarity, positive) +
+        _direction(similarity.mT, positive.mT)
+    )

--- a/nvidia_tao_pytorch/multimodal/clip/model/pl_clip_model.py
+++ b/nvidia_tao_pytorch/multimodal/clip/model/pl_clip_model.py
@@ -30,6 +30,9 @@ from nvidia_tao_pytorch.multimodal.clip.model.logit_calibration import (  # noqa
 from nvidia_tao_pytorch.multimodal.clip.loss.masked_siglip_loss import (  # noqa: E402
     MetadataMaskedSigLipLoss,
 )
+from nvidia_tao_pytorch.multimodal.clip.loss.partial_negative_alignment_loss import (  # noqa: E402
+    partial_negative_alignment_loss,
+)
 from nvidia_tao_pytorch.multimodal.clip.utils.utils import (  # noqa: E402
     build_optimizer,
     compute_lr,
@@ -266,6 +269,18 @@ class CLIPPlModel(TAOLightningModule):
         self.triplet_margin = getattr(
             self.experiment_spec.train, "triplet_margin", 0.2
         )
+        self.pa_loss_weight = getattr(
+            self.experiment_spec.train, "pa_loss_weight", 0.0
+        )
+        self.pa_margin = getattr(
+            self.experiment_spec.train, "pa_margin", 0.2
+        )
+        self.pa_inverse_temperature = getattr(
+            self.experiment_spec.train, "pa_inverse_temperature", 10.0
+        )
+        self.pa_top_ratio = getattr(
+            self.experiment_spec.train, "pa_top_ratio", 0.5
+        )
 
         # PEFT and regularization setup
         peft_cfg = getattr(self.experiment_spec, 'peft', None)
@@ -339,6 +354,8 @@ class CLIPPlModel(TAOLightningModule):
             if siglip_mask_mode in (
                 "attribute_match_ignore",
                 "attribute_plus_accessory_match_ignore",
+                "attribute_match_positive",
+                "attribute_plus_accessory_match_positive",
             ):
                 train_data_cfg = self.experiment_spec.dataset.train
                 if not getattr(
@@ -354,6 +371,19 @@ class CLIPPlModel(TAOLightningModule):
                         f"siglip_loss_mask_mode={siglip_mask_mode!r} requires "
                         "dataset.train.type='custom', got "
                         f"{train_data_type!r}."
+                    )
+                compatible_as_positive = siglip_mask_mode.endswith(
+                    "_positive"
+                )
+                if (
+                    compatible_as_positive and
+                    len(train_data_cfg.datasets) != 1
+                ):
+                    raise ValueError(
+                        f"siglip_loss_mask_mode={siglip_mask_mode!r} "
+                        "currently requires exactly one custom source "
+                        "dataset so compatible positives cannot cross "
+                        "dataset identities."
                     )
                 if self.siglip_loss_dist_impl not in ("local", "gather"):
                     raise NotImplementedError(
@@ -376,13 +406,27 @@ class CLIPPlModel(TAOLightningModule):
                         self.trainer.world_size,
                         siglip_loss_world_size,
                     )
+                train_cfg = getattr(self.experiment_spec, "train", None)
                 self.loss = MetadataMaskedSigLipLoss(
                     dist_impl=self.siglip_loss_dist_impl,
                     world_size=siglip_loss_world_size,
                     rank=siglip_loss_rank,
                     accessory_aware=(
-                        siglip_mask_mode ==
-                        "attribute_plus_accessory_match_ignore"
+                        siglip_mask_mode in (
+                            "attribute_plus_accessory_match_ignore",
+                            "attribute_plus_accessory_match_positive",
+                        )
+                    ),
+                    compatible_as_positive=compatible_as_positive,
+                    compatible_positive_weight=getattr(
+                        train_cfg,
+                        "compatible_positive_weight",
+                        1.0,
+                    ),
+                    compatible_positive_normalization=getattr(
+                        train_cfg,
+                        "compatible_positive_normalization",
+                        "per_pair",
                     ),
                 )
                 self.criterion = self.loss
@@ -630,6 +674,37 @@ class CLIPPlModel(TAOLightningModule):
             loss_value = contrastive_loss
             preservation_active = False
 
+        if (
+            isinstance(self.loss, MetadataMaskedSigLipLoss) and
+            self.loss.compatible_as_positive
+        ):
+            self.log(
+                "train/compatible_positive_pairs_per_rank",
+                self.loss.last_compatible_positive_pairs,
+                on_step=True,
+                on_epoch=True,
+                prog_bar=False,
+                sync_dist=True,
+                batch_size=batch_size,
+            )
+
+        # PA treats metadata-compatible matches as positives rather than
+        # mining them as negatives.
+        compatible_mask = None
+        if self.pa_loss_weight > 0:
+            if isinstance(self.loss, MetadataMaskedSigLipLoss):
+                metadata = _get_attribute_metadata_from_batch(
+                    batch,
+                    context="metadata-aware ranking loss",
+                    require_accessories=self.loss.accessory_aware,
+                )
+                compatible_mask = self.loss.get_metadata_match_mask(
+                    image_attr_values=metadata["image_attr_values"],
+                    text_attr_values=metadata["text_attr_values"],
+                    image_accessory_ids=metadata.get("image_accessory_ids"),
+                    text_accessory_ids=metadata.get("text_accessory_ids"),
+                )
+
         # Optional batch-hard triplet loss, applied on top of the target.
         if self.triplet_loss_weight > 0:
             triplet_loss = _batch_hard_image_text_triplet_loss(
@@ -644,6 +719,27 @@ class CLIPPlModel(TAOLightningModule):
                 sync_dist=True, batch_size=batch_size,
             )
             if not preservation_active:
+                self.log(
+                    "train/contrastive_loss", contrastive_loss,
+                    on_step=True, on_epoch=True, prog_bar=False,
+                    sync_dist=True, batch_size=batch_size,
+                )
+        if self.pa_loss_weight > 0:
+            pa_loss = partial_negative_alignment_loss(
+                image_features,
+                text_features,
+                self.pa_margin,
+                self.pa_inverse_temperature,
+                self.pa_top_ratio,
+                compatible_mask=compatible_mask,
+            )
+            loss_value = loss_value + self.pa_loss_weight * pa_loss
+            self.log(
+                "train/pa_loss", pa_loss,
+                on_step=True, on_epoch=True, prog_bar=False,
+                sync_dist=True, batch_size=batch_size,
+            )
+            if not preservation_active and self.triplet_loss_weight <= 0:
                 self.log(
                     "train/contrastive_loss", contrastive_loss,
                     on_step=True, on_epoch=True, prog_bar=False,

--- a/tests/multimodal_unit_test/clip/test_masked_siglip_loss.py
+++ b/tests/multimodal_unit_test/clip/test_masked_siglip_loss.py
@@ -750,3 +750,70 @@ class TestMetadataMaskedSigLipLoss:
                 image_attr_values=attr_values,
                 text_attr_values=attr_values,
             )
+
+
+def test_positive_mode_promotes_compatible_off_diagonal_terms():
+    """Compatible metadata pairs become weighted positives when enabled."""
+    labels = torch.tensor([
+        [1.0, -1.0, -1.0],
+        [-1.0, 1.0, -1.0],
+        [-1.0, -1.0, 1.0],
+    ])
+    metadata_match = torch.tensor([
+        [True, True, False],
+        [True, True, False],
+        [False, False, True],
+    ])
+    valid_terms = torch.eye(3, dtype=torch.bool) | ~metadata_match
+    loss = MetadataMaskedSigLipLoss(
+        compatible_as_positive=True,
+        compatible_positive_weight=0.5,
+    )
+
+    targets, valid, weights, promoted = loss.get_targets_and_term_weights(
+        labels=labels,
+        valid_terms=valid_terms,
+        metadata_match=metadata_match,
+        positive_text_indices=torch.arange(3),
+    )
+
+    assert promoted[0, 1] and promoted[1, 0]
+    assert targets[0, 1] == 1 and targets[1, 0] == 1
+    assert valid[0, 1] and valid[1, 0]
+    assert weights[0, 1] == 0.5 and weights[1, 0] == 0.5
+
+
+def test_positive_mode_per_query_normalizes_promoted_weight():
+    """Per-query weighting keeps total promoted weight bounded."""
+    labels = -torch.ones(3, 3)
+    labels.fill_diagonal_(1)
+    metadata_match = torch.ones(3, 3, dtype=torch.bool)
+    valid_terms = torch.eye(3, dtype=torch.bool)
+    loss = MetadataMaskedSigLipLoss(
+        compatible_as_positive=True,
+        compatible_positive_weight=0.6,
+        compatible_positive_normalization="per_query",
+    )
+
+    _, _, weights, promoted = loss.get_targets_and_term_weights(
+        labels=labels,
+        valid_terms=valid_terms,
+        metadata_match=metadata_match,
+        positive_text_indices=torch.arange(3),
+    )
+
+    for column in range(3):
+        assert torch.isclose(
+            weights[:, column].masked_select(promoted[:, column]).sum(),
+            torch.tensor(0.6),
+        )
+
+
+def test_positive_mode_validates_weight_and_normalization():
+    """Invalid compatible-positive controls fail before training."""
+    with pytest.raises(ValueError, match="non-negative"):
+        MetadataMaskedSigLipLoss(compatible_positive_weight=-0.1)
+    with pytest.raises(ValueError, match="per_pair.*per_query"):
+        MetadataMaskedSigLipLoss(
+            compatible_positive_normalization="unsupported"
+        )

--- a/tests/multimodal_unit_test/clip/test_pa_experiment_spec.py
+++ b/tests/multimodal_unit_test/clip/test_pa_experiment_spec.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import yaml
+
+
+def test_fixed_pa_reproduction_profile_preserves_recorded_protocol():
+    """The checked-in profile must remain PA-only and protocol-compatible."""
+    spec_path = (
+        Path(__file__).parents[3]
+        / "nvidia_tao_pytorch/multimodal/clip/experiment_specs/pas_v3_1"
+        / "experiment_siglip2_pas_v3_1_dual_tower_lora_pa.yaml"
+    )
+    with spec_path.open(encoding="utf-8") as spec_file:
+        spec = yaml.safe_load(spec_file)
+
+    assert spec["model"]["type"] == "siglip2-so400m-patch16-256"
+    assert spec["peft"]["enabled"] is True
+    assert spec["peft"]["method"] == "lora"
+    assert spec["train"]["num_epochs"] == 20
+    assert spec["train"]["num_gpus"] == 8
+    assert spec["train"]["siglip_loss_dist_impl"] == "gather"
+    assert (
+        spec["train"]["siglip_loss_mask_mode"]
+        == "attribute_plus_accessory_match_positive"
+    )
+    assert spec["train"]["triplet_loss_weight"] == 0.0
+    assert spec["train"]["pa_loss_weight"] > 0.0
+    assert spec["train"]["checkpointer"]["monitor"] == "val/pas/overall_mAP"
+    assert spec["dataset"]["val"]["metadata_match_mode"] == (
+        "scalar_plus_accessories"
+    )
+    assert spec["evaluate"]["pas_ground_truth_mode"] == (
+        "scalar_plus_accessories"
+    )

--- a/tests/multimodal_unit_test/clip/test_partial_negative_alignment_loss.py
+++ b/tests/multimodal_unit_test/clip/test_partial_negative_alignment_loss.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from nvidia_tao_pytorch.multimodal.clip.loss.partial_negative_alignment_loss import (
+    partial_negative_alignment_loss,
+)
+
+
+def test_pa_loss_is_finite_and_differentiable():
+    torch.manual_seed(3)
+    images = torch.randn(8, 16, requires_grad=True)
+    texts = torch.randn(8, 16, requires_grad=True)
+    loss = partial_negative_alignment_loss(images, texts, 0.2, 10.0, 0.5)
+    loss.backward()
+    assert torch.isfinite(loss)
+    assert torch.isfinite(images.grad).all()
+    assert torch.isfinite(texts.grad).all()
+
+
+def test_top_ratio_one_matches_equation_for_diagonal_positives():
+    torch.manual_seed(5)
+    images = torch.randn(7, 12)
+    texts = torch.randn(7, 12)
+    pa = partial_negative_alignment_loss(images, texts, 0.2, 10.0, 1.0)
+    scores = torch.nn.functional.normalize(images, dim=-1) @ (
+        torch.nn.functional.normalize(texts, dim=-1).mT
+    )
+
+    def direction(values):
+        excluded = torch.eye(len(values), dtype=torch.bool)
+        negative = values.masked_fill(excluded, float("-inf"))
+        smooth_negative = torch.logsumexp(10.0 * negative, dim=1) / 10.0
+        return torch.relu(0.2 - values.diag() + smooth_negative).mean()
+
+    reference = 0.5 * (direction(scores) + direction(scores.mT))
+    assert torch.allclose(pa, reference, atol=1e-6, rtol=1e-6)
+
+
+def test_compatible_pairs_are_positives_not_negatives():
+    images = torch.eye(4, requires_grad=True)
+    texts = torch.roll(torch.eye(4), shifts=1, dims=0).requires_grad_()
+    compatible = torch.zeros(4, 4, dtype=torch.bool)
+    compatible[0, 1] = True
+    masked = partial_negative_alignment_loss(
+        images, texts, 0.2, 10.0, 0.5, compatible_mask=compatible
+    )
+    unmasked = partial_negative_alignment_loss(images, texts, 0.2, 10.0, 0.5)
+    assert masked < unmasked
+    masked.backward()
+    assert torch.isfinite(images.grad).all()
+
+
+def test_all_compatible_pairs_return_zero():
+    features = torch.eye(3)
+    compatible = torch.ones(3, 3, dtype=torch.bool)
+    loss = partial_negative_alignment_loss(
+        features, features, 0.2, 10.0, 0.5, compatible_mask=compatible
+    )
+    assert loss.item() == 0.0
+
+
+@pytest.mark.parametrize("temperature", [0.0, -1.0])
+def test_invalid_temperature_rejected(temperature):
+    features = torch.eye(3)
+    with pytest.raises(ValueError, match="inverse temperature"):
+        partial_negative_alignment_loss(features, features, 0.2, temperature, 0.5)
+
+
+@pytest.mark.parametrize("ratio", [0.0, -0.1, 1.1])
+def test_invalid_ratio_rejected(ratio):
+    features = torch.eye(3)
+    with pytest.raises(ValueError, match="top_ratio"):
+        partial_negative_alignment_loss(features, features, 0.2, 10.0, ratio)
+
+
+def test_invalid_margin_and_mismatched_batches_rejected():
+    features = torch.eye(3)
+    with pytest.raises(ValueError, match="margin"):
+        partial_negative_alignment_loss(features, features, -0.1, 10.0, 0.5)
+    with pytest.raises(ValueError, match="equal image and text"):
+        partial_negative_alignment_loss(features, features[:2], 0.2, 10.0, 0.5)

--- a/tests/multimodal_unit_test/clip/test_siglip_loss_dist_impl.py
+++ b/tests/multimodal_unit_test/clip/test_siglip_loss_dist_impl.py
@@ -47,8 +47,10 @@ def _build_siglip_loss(
                 train=SimpleNamespace(
                     include_attribute_metadata=include_attribute_metadata,
                     type=dataset_type,
+                    datasets=[SimpleNamespace()],
                 ),
             ),
+            train=CLIPTrainConfig(),
         ),
     )
     CLIPPlModel._build_criterion(model)
@@ -69,6 +71,9 @@ class TestSigLipLossDistImpl:
             "siglip_loss_mask_mode"
         ]
         assert "attribute_plus_accessory_match_ignore" in (
+            mask_field.metadata["valid_options"].split(",")
+        )
+        assert "attribute_plus_accessory_match_positive" in (
             mask_field.metadata["valid_options"].split(",")
         )
 
@@ -124,6 +129,17 @@ class TestSigLipLossDistImpl:
 
         assert isinstance(loss, MetadataMaskedSigLipLoss)
         assert loss.accessory_aware is True
+
+    def test_positive_mask_mode_promotes_compatible_pairs(self):
+        """Test positive mode is wired to the metadata-aware loss."""
+        loss = _build_siglip_loss(
+            "local",
+            mask_mode="attribute_plus_accessory_match_positive",
+        )
+
+        assert isinstance(loss, MetadataMaskedSigLipLoss)
+        assert loss.accessory_aware is True
+        assert loss.compatible_as_positive is True
 
     @pytest.mark.parametrize(
         "mask_mode",


### PR DESCRIPTION
## What this draft adds

- implements the Partial-negative Alignment (PA) auxiliary retrieval loss;
- makes PAS metadata-compatible pairs PA positives instead of hard negatives;
- adds an opt-in metadata-positive SigLIP mode with bounded per-query weighting;
- keeps all behavior backward compatible when `pa_loss_weight: 0`;
- checks in the fixed PAS V3.1.1 SigLIP2-256 + standard LoRA reproduction spec and protocol notes.

This implements only the PA component of Song et al., *Dual alignment: Partial negative and soft-label alignment for text-to-image person retrieval* (Information Fusion 127, 2026; DOI `10.1016/j.inffus.2025.103644`). It does **not** implement the paper's soft-label alignment component and must not be described as the full paper method.

## Reproduction scope

The checked-in profile is intentionally:

- SigLIP2 SO400M patch16 at 256px;
- standard dual-tower LoRA (not RandLoRA);
- 20 epochs on 8 GPUs;
- validation selection by `val/pas/overall_mAP`;
- no AutoML, 384px training, reranking, AQE, or score fusion.

The historical fixed run selected `model_best_002.pth` and reported validation 85.8242% mAP / 83.9294% Rank-1 and test 83.7930% mAP / 83.0727% Rank-1. These are evidence for the checked-in protocol, not CI tolerances.

## Compatibility constraint

Metadata-positive SigLIP currently accepts exactly one custom source dataset. This prevents a metadata match from silently promoting examples across unrelated dataset identities. Multi-source positive promotion should add explicit source IDs in a follow-up.

## Validation

- TAO 6.25.11 PyTorch container: 45 focused tests passed.
- `flake8`: passed on changed source files.
- `pydocstyle`: passed on changed source files.
- `pylint`: 10.00/10 on changed source files.
- `git diff --check`: passed.

## Review notes

This draft is based on `feature/clip-lora-dev-for-deft` so it can be reviewed directly on top of the original CLIP LoRA/PAS work. The new fields are opt-in and default to the pre-existing behavior.
