### PR TITLE
[Bugfix] Patch av==17.1.0 into release image (base image missing PyAV)

### DIFF
--- a/release/docker/Dockerfile
+++ b/release/docker/Dockerfile
@@ -69,6 +69,7 @@ ENV RUN_CLI=0
 # layers and overlay2 caps a container at 128, so every extra RUN/COPY layer counts;
 # collapsing these three steps into one keeps the release image buildable.
 RUN cd /opt/nvidia/wheels && ls ./*.whl | xargs -I'{}' python -m pip install '{}' && rm -f *.whl && \
+    python -m pip install 'av==17.1.0' 'onnxscript==0.7.1' && \
     python -c 'import importlib.util; from importlib.metadata import version; import av, onnxscript; assert version("av") == "17.1.0"; assert version("onnxscript") == "0.7.1"; assert importlib.util.find_spec("decord") is None; print(f"FC video dependencies: av={av.__version__}, onnxscript={onnxscript.__version__}, decord=absent")' && \
     ARCH_LIB_PATH="/usr/lib/$(uname -m)-linux-gnu" && \
     sed -i "s|export LD_LIBRARY_PATH=${ARCH_LIB_PATH}:\${LD_LIBRARY_PATH}|export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:${ARCH_LIB_PATH}|g" /etc/bash.bashrc && \


### PR DESCRIPTION
## Problem
`tao-pytorch-OSS-release` **nightly** (SOURCE=github, BRANCH_NAME=main) fails at stage-2 step 7/7:
```
Successfully installed nvidia-tao-pytorch-…
ModuleNotFoundError: No module named 'av'
```
The *FC video dependencies* assert (`import av, onnxscript; assert version("av")=="17.1.0"`) was added after nightly build 56 (56 green, 57-59 red), but `tao_pytorch_base_image` no longer ships `av` → fails on **x86 (#786) and arm64 (#507)**.

## Fix
Install `av==17.1.0` (+ pin `onnxscript==0.7.1` defensively) from the official PyPI wheels **inside the existing wheels RUN layer**, before the verification:
- abi3 manylinux_2_28 wheels exist for **both x86_64 and aarch64** → no source build.
- Same `RUN` → **no extra layer** (overlay2 128-layer cap).
- Assert only checks the version; the official wheel bundles ffmpeg w/ software decoders.

## Validation
Same patch on `release/7.2.0` (#117) built **green on both arches** via `tao-pytorch-OSS-release` build 60 — the av step now prints `FC video dependencies: av=17.1.0, onnxscript=0.7.1, decord=absent` on x86 and arm64.

Companion to #117. Release-side patch until `tao_pytorch_base_image` ships `av` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)