### PR TITLE
[TAOVN-1251][Feature] Add NVPanoptix3Dv2 model module

### DIFF
--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 model module."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/build_pl_model.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/build_pl_model.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the PyTorch Lightning module for the selected NVPanoptix3Dv2 variant.
+
+Both variants share the frozen VGGT backbone and the metric scale head; they
+diverge above the geometry layer, so each owns its own Lightning module. The
+subtask scripts stay variant-agnostic and go through :func:`build_pl_model`.
+"""
+
+PANOPTIC = "panoptic"
+REASONING = "reasoning"
+SUPPORTED_MODEL_TYPES = (PANOPTIC, REASONING)
+
+
+def pl_module_class(model_type: str):
+    """Import and return the Lightning module class for ``model_type``.
+
+    The imports are deferred because the two variants pull in disjoint and
+    heavy third-party stacks (SigLIP for panoptic, Qwen/PEFT/SAM3 for
+    reasoning). Importing eagerly would make either variant unusable whenever
+    the other's dependencies are absent.
+    """
+    if model_type == PANOPTIC:
+        from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.pl_model import (
+            NVPanoptix3Dv2PanopticPlModule,
+        )
+        return NVPanoptix3Dv2PanopticPlModule
+    if model_type == REASONING:
+        from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning.pl_model import (
+            NVPanoptix3Dv2ReasoningPlModule,
+        )
+        return NVPanoptix3Dv2ReasoningPlModule
+    raise ValueError(
+        f"Unsupported model.model_type {model_type!r}. "
+        f"Supported: {', '.join(SUPPORTED_MODEL_TYPES)}"
+    )
+
+
+def get_pl_module(experiment_config):
+    """Return the Lightning module class selected by ``model.model_type``.
+
+    Args:
+        experiment_config: the experiment config, with ``model.model_type`` set
+            to one of ``panoptic`` or ``reasoning``.
+
+    Returns:
+        The Lightning module class for that variant.
+    """
+    return pl_module_class(str(experiment_config.model.model_type))
+
+
+def build_pl_model(experiment_config):
+    """Instantiate the Lightning module selected by ``model.model_type``.
+
+    Args:
+        experiment_config: the experiment config.
+
+    Returns:
+        An initialized Lightning module for the configured variant.
+    """
+    return get_pl_module(experiment_config)(experiment_config)
+
+
+def load_pl_model(experiment_config, checkpoint_path: str, **kwargs):
+    """Load the configured variant's Lightning module from a checkpoint.
+
+    Args:
+        experiment_config: the experiment config.
+        checkpoint_path: path to the ``.pth`` checkpoint to restore.
+        **kwargs: forwarded to ``load_from_checkpoint``.
+
+    Returns:
+        The restored Lightning module.
+    """
+    return get_pl_module(experiment_config).load_from_checkpoint(
+        checkpoint_path,
+        map_location="cpu",
+        experiment_config=experiment_config,
+        **kwargs,
+    )

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/metric_scale_head.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/metric_scale_head.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Metric scale head for NVPanoptix3Dv2.
+
+VGGT predicts depth in normalised scene coordinates (mean depth ~ 1). This head
+regresses one global correction per scene,
+
+    d_metric = s * d_rel + b,    s = exp(log_s) > 0
+
+from a ``[B, 13 + C]`` descriptor of the scene's absolute physical scale:
+
+     4  camera baseline     mean/std/min/max of ``||t_i - t_j||`` over view pairs
+     2  translation norm    mean/std of ``||t_i||``
+     5  depth distribution  mean/std/median/p10/p90 of ``d_rel``, view-averaged
+     2  focal length        mean/std of ``(fx + fy) / 2``
+     C  scene token         VGGT patch tokens mean-pooled over views and patches
+
+Exponentiating ``log_s`` keeps the scale positive without clamping. The shift
+``b`` is regressed only when ``predict_shift`` is set; disabling it gives the
+scale-only correction ``d_metric = s * d_rel`` used by the panoptic variant.
+It lives in depth units and is never applied to 3D points.
+"""
+
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+SCALAR_FEAT_DIM = 13  # 4 baseline + 2 translation + 5 depth + 2 focal
+
+
+def mean_std(values: torch.Tensor) -> torch.Tensor:
+    """Mean and population std over the last axis, stacked as ``[..., 2]``.
+
+    ``unbiased=False`` keeps the std well-defined when the axis holds a single
+    element, which happens for a one-view context.
+    """
+    return torch.stack(
+        [values.mean(dim=-1), values.std(dim=-1, unbiased=False)], dim=-1,
+    )
+
+
+def pose_encoding_to_intrinsics(
+    pose_encoding: torch.Tensor,
+    image_size_hw,
+) -> torch.Tensor:
+    """Reconstruct camera intrinsics from VGGT FoV pose components.
+
+    Args:
+        pose_encoding: VGGT camera encoding shaped ``[B, S, 9]``. Its final
+            two values are the vertical and horizontal fields of view.
+        image_size_hw: Input image ``(height, width)``.
+
+    Returns:
+        Camera intrinsics shaped ``[B, S, 3, 3]``.
+
+    Raises:
+        ValueError: If the pose encoding does not end in nine values.
+    """
+    if pose_encoding.shape[-1] != 9:
+        raise ValueError(
+            "VGGT pose encoding must end in 9 values, got "
+            f"shape {tuple(pose_encoding.shape)}"
+        )
+
+    height, width = image_size_hw
+    fov_h = pose_encoding[..., 7]
+    fov_w = pose_encoding[..., 8]
+    intrinsics = pose_encoding.new_zeros(pose_encoding.shape[:2] + (3, 3))
+    intrinsics[..., 0, 0] = (width / 2.0) / torch.tan(fov_w / 2.0)
+    intrinsics[..., 1, 1] = (height / 2.0) / torch.tan(fov_h / 2.0)
+    intrinsics[..., 0, 2] = width / 2.0
+    intrinsics[..., 1, 2] = height / 2.0
+    intrinsics[..., 2, 2] = 1.0
+    return intrinsics
+
+
+class MetricScaleHead(nn.Module):
+    """Predict one global metric scale correction for VGGT depth.
+
+    Args:
+        scene_token_dim: Channel dim of the pooled VGGT patch token (2048 for
+            the 1024-dim aggregator).
+        hidden_dims: Hidden widths of the MLP.
+        depth_min: Lower clamp applied when computing the depth statistics,
+            avoiding percentile blow-up at zero depth.
+        depth_max: Upper clamp applied when computing the depth statistics.
+        metric_context_views: Deterministic view prefix used to estimate scale,
+            so 20/50-view inference sees the training-time view-count
+            distribution. Inputs with fewer views use all of them.
+        predict_shift: Also regress the additive shift ``b``.
+    """
+
+    def __init__(
+        self,
+        scene_token_dim: int = 2048,
+        hidden_dims=(256, 64),
+        depth_min: float = 1e-3,
+        depth_max: float = 1e3,
+        metric_context_views: int = 5,
+        predict_shift: bool = True,
+    ):
+        super().__init__()
+        if metric_context_views <= 0:
+            raise ValueError(
+                f"metric_context_views must be positive, got {metric_context_views}"
+            )
+        self.depth_min = depth_min
+        self.depth_max = depth_max
+        self.metric_context_views = int(metric_context_views)
+        self.predict_shift = bool(predict_shift)
+
+        layers = []
+        in_dim = SCALAR_FEAT_DIM + scene_token_dim
+        for hidden in hidden_dims:
+            layers += [nn.Linear(in_dim, hidden), nn.LayerNorm(hidden), nn.GELU()]
+            in_dim = hidden
+        # Zero-init the output layer so the head starts as the identity
+        # (s = 1, b = 0) before training.
+        out_layer = nn.Linear(in_dim, 2 if self.predict_shift else 1)
+        nn.init.zeros_(out_layer.weight)
+        nn.init.zeros_(out_layer.bias)
+        self.mlp = nn.Sequential(*layers, out_layer)
+
+    def depth_stats(self, rel_depth: torch.Tensor) -> torch.Tensor:
+        """Per-view depth distribution stats averaged over views, ``[B, 5]``.
+
+        Returns (mean, std, median, p10, p90). ONNX export swaps this method for
+        a sort-based equivalent, since ``torch.quantile`` has no lowering -- see
+        ``nvpanoptix3d_v2.export.onnx_exporter.depth_stats_export_safe``.
+
+        Args:
+            rel_depth: ``[B, S, H, W, 1]`` or ``[B, S, H, W]`` normalised depth.
+        """
+        if rel_depth.dim() == 5:
+            rel_depth = rel_depth.squeeze(-1)
+        batch, views = rel_depth.shape[:2]
+        d = rel_depth.reshape(batch, views, -1).clamp(self.depth_min, self.depth_max)
+
+        # Ordered to match the stack below, so the result unpacks directly.
+        qs = torch.tensor([0.5, 0.1, 0.9], device=d.device, dtype=d.dtype)
+        median, p10, p90 = torch.quantile(d, qs, dim=-1)  # each [B, S]
+
+        per_view = torch.stack(
+            [d.mean(dim=-1), d.std(dim=-1, unbiased=False), median, p10, p90], dim=-1,
+        )
+        return per_view.mean(dim=1)
+
+    def forward(
+        self,
+        vggt_feats: torch.Tensor,
+        rel_depth: torch.Tensor,
+        pose_enc: torch.Tensor,
+        image_size_hw,
+    ) -> Dict[str, torch.Tensor]:
+        """Predict the per-scene scale from a fixed view prefix.
+
+        Args:
+            vggt_feats: ``[B, S, P, C]`` VGGT patch tokens (frozen).
+            rel_depth: ``[B, S, H, W, 1]`` or ``[B, S, H, W]`` VGGT depth in
+                normalised units (frozen).
+            pose_enc: ``[B, S, 9]`` VGGT pose encoding (frozen).
+            image_size_hw: ``(H, W)`` for the FoV -> focal length conversion.
+
+        Returns:
+            Dict with ``log_s`` and ``scale`` ``[B, 1]``, ``intrinsics``
+            ``[B, S, 3, 3]`` for *all* views, and ``b`` ``[B, 1]`` when
+            ``predict_shift`` is set.
+
+        Raises:
+            ValueError: If there are no views, or the three inputs disagree on
+                the view count.
+        """
+        n_views = vggt_feats.shape[1]
+        if n_views == 0:
+            raise ValueError("Metric scale estimation requires at least one view")
+        if rel_depth.shape[1] != n_views or pose_enc.shape[1] != n_views:
+            raise ValueError(
+                "Metric-head view counts must match: "
+                f"vggt_feats={n_views}, rel_depth={rel_depth.shape[1]}, "
+                f"pose_enc={pose_enc.shape[1]}"
+            )
+
+        # Decode every camera -- intrinsics are a per-view downstream output.
+        # Only the context prefix feeds the scale features.
+        intrinsics = pose_encoding_to_intrinsics(pose_enc.float(), image_size_hw)
+        context = slice(0, min(n_views, self.metric_context_views))
+
+        # Features are built under no_grad: the head must never backprop into
+        # VGGT, so its input is a constant.
+        with torch.no_grad():
+            translations = pose_enc[:, context, :3].float()  # [B, S, 3]
+            n_context = translations.shape[1]
+            if n_context < 2:
+                baseline = translations.new_zeros(translations.shape[0], 4)
+            else:
+                # Strict upper-triangular pairs of ||t_i - t_j||, [B, C(S,2)].
+                dist = (translations.unsqueeze(2) - translations.unsqueeze(1)).norm(dim=-1)
+                iu, ju = torch.triu_indices(
+                    n_context, n_context, offset=1, device=dist.device,
+                )
+                pairs = dist[:, iu, ju]
+                baseline = torch.stack(
+                    [
+                        pairs.mean(dim=-1), pairs.std(dim=-1, unbiased=False),
+                        pairs.amin(dim=-1), pairs.amax(dim=-1),
+                    ],
+                    dim=-1,
+                )
+
+            intr = intrinsics[:, context]
+            focals = 0.5 * (intr[..., 0, 0] + intr[..., 1, 1])  # [B, S]
+
+            feats = torch.cat(
+                [
+                    baseline,                                          # [B, 4]
+                    mean_std(translations.norm(dim=-1)),              # [B, 2]
+                    self.depth_stats(rel_depth[:, context].float()),  # [B, 5]
+                    mean_std(focals),                                 # [B, 2]
+                    vggt_feats[:, context].float().mean(dim=(1, 2)),   # [B, C]
+                ],
+                dim=-1,
+            )
+
+        out = self.mlp(feats)
+        log_s = out[:, 0:1]
+        params = {"log_s": log_s, "scale": log_s.exp(), "intrinsics": intrinsics}
+        if self.predict_shift:
+            params["b"] = out[:, 1:2]
+        return params
+
+
+def apply_metric_scale(
+    rel_depth: torch.Tensor,
+    params: Dict[str, torch.Tensor],
+) -> torch.Tensor:
+    """Apply the global correction ``d_metric = s * d_rel + b``.
+
+    ``b`` is only present when the head was built with ``predict_shift``;
+    otherwise this reduces to ``d_metric = s * d_rel``.
+
+    Args:
+        rel_depth: ``[B, S, H, W, 1]`` or ``[B, S, H, W]`` VGGT depth.
+        params: Dict from :meth:`MetricScaleHead.forward`, carrying ``scale``
+            ``[B, 1]`` and optionally ``b`` ``[B, 1]``.
+
+    Returns:
+        ``metric_depth``, shaped like ``rel_depth``.
+
+    Raises:
+        ValueError: If ``rel_depth`` is neither 4D nor 5D.
+    """
+    if rel_depth.dim() not in (4, 5):
+        raise ValueError(
+            f"rel_depth must be 4D or 5D, got shape {tuple(rel_depth.shape)}"
+        )
+
+    # ``scale``/``b`` are [B, 1]; broadcast over the view and pixel axes.
+    shape = (-1, 1) + (1,) * (rel_depth.dim() - 2)
+    metric_depth = params["scale"].reshape(shape) * rel_depth
+    shift = params.get("b")
+    if shift is not None:
+        metric_depth = metric_depth + shift.reshape(shape)
+    return metric_depth

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Panoptic-segmentation variant of the NVPanoptix3Dv2 model."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/feature_fusion.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/feature_fusion.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 visual feature fusion.
+
+NVPanoptix3Dv2 concatenates its frozen visual streams, including DINO and VGGT.
+Views are processed independently, so the mixer has no ordinal frame encoding
+or view-count-dependent operation. Geometry is deliberately not injected.
+"""
+
+import torch
+from torch import nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.block import Block
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.rope import (
+    RotaryPositionEmbedding2D,
+)
+
+
+class ConcatenatedFeatureFusion(nn.Module):
+    """Concatenate/project DINO+VGGT, then spatially mix each view."""
+
+    def __init__(
+        self,
+        dino_dim: int = 1024,
+        vggt_dim: int = 2048,
+        hidden_dim: int = 768,
+        num_heads: int = 12,
+        num_layers: int = 3,
+        ff_dim_mult: float = 4.0,
+    ):
+        super().__init__()
+        self.dino_dim = int(dino_dim)
+        self.vggt_dim = int(vggt_dim)
+        self.hidden_dim = int(hidden_dim)
+        self.num_heads = int(num_heads)
+        self.num_layers = int(num_layers)
+        if self.num_layers < 0:
+            raise ValueError(f"num_layers must be non-negative, got {num_layers}")
+        if self.num_layers > 0:
+            if self.num_heads <= 0 or self.hidden_dim % self.num_heads != 0:
+                raise ValueError(
+                    f"hidden_dim={hidden_dim} must be divisible by a positive "
+                    f"num_heads={num_heads}"
+                )
+            if (self.hidden_dim // self.num_heads) % 4 != 0:
+                raise ValueError(
+                    "2D RoPE requires attention head_dim to be divisible by "
+                    f"4, got {self.hidden_dim // self.num_heads}"
+                )
+
+        self.proj = nn.Linear(
+            self.dino_dim + self.vggt_dim, self.hidden_dim,
+        )
+        rope = RotaryPositionEmbedding2D(frequency=100.0)
+        self.mixer_blk = nn.ModuleList([
+            Block(
+                dim=self.hidden_dim,
+                num_heads=self.num_heads,
+                mlp_ratio=float(ff_dim_mult),
+                qkv_bias=True,
+                proj_bias=True,
+                ffn_bias=True,
+                drop=0.0,
+                attn_drop=0.0,
+                drop_path=0.0,
+                qk_norm=False,
+                fused_attn=True,
+                rope=rope,
+            )
+            for _ in range(self.num_layers)
+        ])
+        self.out_norm = nn.LayerNorm(self.hidden_dim)
+
+    @staticmethod
+    def spatial_positions(
+        batch_size: int,
+        height: int,
+        width: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Return row-major ``(y, x)`` positions for the native patch grid."""
+        y, x = torch.meshgrid(
+            torch.arange(height, device=device),
+            torch.arange(width, device=device),
+            indexing="ij",
+        )
+        positions = torch.stack((y, x), dim=-1).reshape(1, height * width, 2)
+        return positions.expand(batch_size, -1, -1)
+
+    def forward(
+        self,
+        f_dino: torch.Tensor,
+        f_vggt: torch.Tensor,
+        spatial_shape=None,
+    ) -> torch.Tensor:
+        """Project the concatenated DINOv2/VGGT tokens and refine them per view."""
+        if f_dino.shape[:-1] != f_vggt.shape[:-1]:
+            raise ValueError(
+                "DINO and VGGT token shapes must match before channels: "
+                f"{tuple(f_dino.shape)} vs {tuple(f_vggt.shape)}"
+            )
+
+        x = self.proj(torch.cat([f_dino, f_vggt], dim=-1))
+        if self.mixer_blk:
+            if spatial_shape is None:
+                raise ValueError(
+                    "spatial_shape=(patch_h, patch_w) is required when the "
+                    "spatial mixer is enabled"
+                )
+            patch_h, patch_w = int(spatial_shape[0]), int(spatial_shape[1])
+            if patch_h <= 0 or patch_w <= 0:
+                raise ValueError(
+                    f"spatial_shape must be positive, got {(patch_h, patch_w)}"
+                )
+            if x.shape[1] != patch_h * patch_w:
+                raise ValueError(
+                    "Token count does not match the native patch grid: "
+                    f"P={x.shape[1]}, grid={patch_h}*{patch_w}"
+                )
+            positions = self.spatial_positions(
+                x.shape[0], patch_h, patch_w, x.device,
+            )
+            for block in self.mixer_blk:
+                x = block(x, pos=positions)
+
+        return self.out_norm(x)

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/loftup.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/loftup.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LoftUp Upscaler for NVPanoptix3Dv2.
+
+Self-contained implementation adapted from the LoftUp project
+(https://github.com/andrehuang/loftup, MIT License).
+
+Generates high-resolution mask features by cross-attending Fourier-encoded
+image features with low-resolution patch features. No InputMixer — the
+concatenated DINO/VGGT features are used directly. Spatial tensors always
+remain in the input image's actual ``(H, W)`` orientation.
+
+All building blocks (CrossAttention, Mlp, DropPath, CrossonlyDecoderBlock)
+are inlined to avoid external dependencies on croco.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.mlp import Mlp
+
+
+# Inlined building blocks (originally from croco.models.blocks)
+
+class DropPath(nn.Module):
+    """Stochastic depth (drop entire residual branch during training)."""
+
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass."""
+        if not self.training or self.drop_prob == 0.0:
+            return x
+        keep = torch.rand(x.shape[0], 1, 1, device=x.device, dtype=x.dtype) >= self.drop_prob
+        return x / (1.0 - self.drop_prob) * keep
+
+
+class CrossAttention(nn.Module):
+    """Multi-head cross-attention (no RoPE — simplified for LoftUp use)."""
+
+    def __init__(self, dim, num_heads=8, qkv_bias=False, attn_drop=0.0, proj_drop=0.0):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+
+        self.q_proj = nn.Linear(dim, dim, bias=qkv_bias)
+        self.k_proj = nn.Linear(dim, dim, bias=qkv_bias)
+        self.v_proj = nn.Linear(dim, dim, bias=qkv_bias)
+        self.proj = nn.Linear(dim, dim)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, query, key, value):
+        """Forward pass."""
+        B, Nq, C = query.shape
+        Nk = key.shape[1]
+
+        q = self.q_proj(query).reshape(B, Nq, self.num_heads, self.head_dim).permute(0, 2, 1, 3)
+        k = self.k_proj(key).reshape(B, Nk, self.num_heads, self.head_dim).permute(0, 2, 1, 3)
+        v = self.v_proj(value).reshape(B, Nk, self.num_heads, self.head_dim).permute(0, 2, 1, 3)
+
+        # F.scaled_dot_product_attention dispatches to Flash Attention 2 / a
+        # memory-efficient kernel and never materializes the (Nq, Nk) matrix.
+        # The original eager form (attn = (q @ k.T) * scale; softmax; @ v)
+        # allocates ~Nq*Nk*B*heads*dtype_bytes which OOMs at multi-view
+        # inference: e.g. 50 views * (518/14)^2 = 68k tokens -> 34 GiB.
+        # Functionally identical for inference (no dropout in eval mode).
+        x = F.scaled_dot_product_attention(
+            q, k, v,
+            dropout_p=self.attn_drop.p if self.training else 0.0,
+        )
+
+        x = x.transpose(1, 2).reshape(B, Nq, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+
+class CrossonlyDecoderBlock(nn.Module):
+    """Cross-attention decoder block: cross-attn + FFN with pre-norm."""
+
+    def __init__(self, dim, num_heads, mlp_ratio=4.0,
+                 qkv_bias=False, drop=0.0, attn_drop=0.0, drop_path=0.0,
+                 act_layer=nn.GELU, norm_layer=nn.LayerNorm, norm_mem=True):
+        super().__init__()
+        self.cross_attn = CrossAttention(
+            dim, num_heads=num_heads,
+            qkv_bias=qkv_bias, attn_drop=attn_drop, proj_drop=drop,
+        )
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.norm2 = norm_layer(dim)
+        self.norm3 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim,
+                       act_layer=act_layer, drop=drop)
+        self.norm_y = norm_layer(dim) if norm_mem else nn.Identity()
+
+    def forward(self, x, y):
+        """Forward pass."""
+        y_ = self.norm_y(y)
+        x = x + self.drop_path(self.cross_attn(self.norm2(x), y_, y_))
+        x = x + self.drop_path(self.mlp(self.norm3(x)))
+        return x
+
+
+# LoftUp components
+
+class MinMaxScaler(nn.Module):
+    """Rescale each channel of a feature map to the unit range."""
+
+    def forward(self, x):
+        """Forward pass."""
+        c = x.shape[1]
+        flat_x = x.permute(1, 0, 2, 3).reshape(c, -1)
+        flat_x_min = flat_x.min(dim=-1).values.reshape(1, c, 1, 1)
+        flat_x_scale = flat_x.max(dim=-1).values.reshape(1, c, 1, 1) - flat_x_min
+        return ((x - flat_x_min) / flat_x_scale.clamp_min(0.0001)) - 0.5
+
+
+class ImplicitFeaturizer(nn.Module):
+    """Fourier positional / color features for high-res guidance tokens."""
+
+    def __init__(self, color_feats=True, n_freqs=10):
+        super().__init__()
+        self.color_feats = color_feats
+        self.n_freqs = n_freqs
+
+        self.dim_multiplier = 2
+        if self.color_feats:
+            self.dim_multiplier += 3
+        self.biases = nn.Parameter(
+            torch.randn(2, self.dim_multiplier, n_freqs, dtype=torch.float32)
+        )
+
+    def forward(self, original_image):
+        """Lift an RGB image to Fourier-encoded features conditioned on colour."""
+        b, _, h, w = original_image.shape
+        grid_h = torch.linspace(-1, 1, h, device=original_image.device)
+        grid_w = torch.linspace(-1, 1, w, device=original_image.device)
+        feats = torch.cat(
+            [t.unsqueeze(0) for t in torch.meshgrid(grid_h, grid_w, indexing="ij")]
+        ).unsqueeze(0)
+        feats = feats.expand(b, -1, -1, -1)
+
+        if self.color_feats:
+            feat_list = [feats, original_image]
+        else:
+            feat_list = [feats]
+
+        feats = torch.cat(feat_list, dim=1).unsqueeze(1)
+        freqs = torch.exp(
+            torch.linspace(-2, 10, self.n_freqs, device=original_image.device)
+        ).reshape(1, self.n_freqs, 1, 1, 1)
+        feats = feats * freqs
+
+        sin_feats = feats + self.biases[0].reshape(
+            1, self.n_freqs, self.dim_multiplier, 1, 1,
+        )
+        cos_feats = feats + self.biases[1].reshape(
+            1, self.n_freqs, self.dim_multiplier, 1, 1,
+        )
+
+        sin_feats = sin_feats.reshape(b, self.n_freqs * self.dim_multiplier, h, w)
+        cos_feats = cos_feats.reshape(b, self.n_freqs * self.dim_multiplier, h, w)
+
+        if self.color_feats:
+            all_feats = [torch.sin(sin_feats), torch.cos(cos_feats), original_image]
+        else:
+            all_feats = [torch.sin(sin_feats), torch.cos(cos_feats)]
+
+        return torch.cat(all_feats, dim=1)
+
+
+class LoftUpUpscaler(nn.Module):
+    """
+    LoftUp-based upscaler that produces high-resolution mask features.
+
+    Takes (lr_feats, images) and returns (fpn, mask_feats):
+      - fpn:        None (the decoder uses one native-resolution memory level)
+      - mask_feats: high-res features at output_stride via Fourier + cross-attention
+
+    No InputMixer — receives fused visual features directly. Both patch
+    tokens and RGB guidance stay in the input image's actual orientation;
+    LoftUp never rotates portrait inputs internally.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        dim: int,
+        output_stride: int = 2,
+        patch_size: int = 14,
+        color_feats: bool = True,
+        n_freqs: int = 20,
+        num_heads: int = 4,
+        num_layers: int = 2,
+    ):
+        super().__init__()
+
+        self.output_stride = output_stride
+        self.patch_size = patch_size
+
+        if color_feats:
+            start_dim = 5 * n_freqs * 2 + 3  # (2 coord + 3 rgb) * n_freqs * 2(sin/cos) + 3(raw rgb)
+        else:
+            start_dim = 2 * n_freqs * 2
+
+        self.lr_pe = ImplicitFeaturizer(color_feats=False, n_freqs=5)
+        concat_dim = input_dim + 2 * 5 * 2
+
+        self.lr_input_proj = nn.Sequential(
+            nn.Linear(concat_dim, dim),
+            nn.LayerNorm(dim),
+        )
+
+        self.fourier_feat = nn.Sequential(
+            MinMaxScaler(),
+            ImplicitFeaturizer(color_feats, n_freqs=n_freqs),
+        )
+
+        self.first_conv = nn.Sequential(
+            nn.GroupNorm(num_groups=1, num_channels=start_dim),
+            nn.Conv2d(start_dim, dim, kernel_size=3, padding=1),
+            nn.GroupNorm(num_groups=8, num_channels=dim),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(dim, dim, kernel_size=3, padding=1),
+            nn.GroupNorm(num_groups=8, num_channels=dim),
+            nn.ReLU(inplace=True),
+        )
+
+        self.ca_transformer_blocks = nn.ModuleList([
+            CrossonlyDecoderBlock(dim=dim, num_heads=num_heads, mlp_ratio=1)
+            for _ in range(num_layers)
+        ])
+        self.ca_transformer_norm = nn.LayerNorm(dim)
+
+    def forward(self, inputs, img_shape):
+        """
+        Args:
+            inputs: (lr_feats, img)
+                lr_feats: [B, P, C] — fused patch tokens (no InputMixer)
+                img:      [B, 3, H, W] — guidance images
+            img_shape: (H, W), which must match ``img.shape[-2:]``
+
+        Returns:
+            (None, mask_feats) where mask_feats: [B, dim, H_out, W_out] high-res features
+        """
+        lr_feats, img = inputs
+        H, W = (int(img_shape[0]), int(img_shape[1]))
+
+        if tuple(img.shape[-2:]) != (H, W):
+            raise ValueError(
+                "LoftUp img_shape must match the actual RGB tensor: "
+                f"img_shape={(H, W)}, tensor_shape={tuple(img.shape[-2:])}"
+            )
+        if H % self.patch_size != 0 or W % self.patch_size != 0:
+            raise ValueError(
+                f"Image shape {(H, W)} must be divisible by patch_size="
+                f"{self.patch_size}"
+            )
+
+        ph, pw = H // self.patch_size, W // self.patch_size
+        expected_patches = ph * pw
+        if lr_feats.shape[1] != expected_patches:
+            raise ValueError(
+                "LoftUp patch-token count does not match the image grid: "
+                f"got P={lr_feats.shape[1]}, expected {ph}*{pw}="
+                f"{expected_patches} for image shape {(H, W)}"
+            )
+        lr_feats_2d = lr_feats.transpose(-1, -2).view(
+            lr_feats.shape[0], -1, ph, pw
+        )
+
+        if self.output_stride <= 0:
+            raise ValueError(
+                f"output_stride must be positive, got {self.output_stride}"
+            )
+        if H % self.output_stride != 0 or W % self.output_stride != 0:
+            raise ValueError(
+                f"Image shape {(H, W)} must be divisible by output_stride="
+                f"{self.output_stride}"
+            )
+        if self.output_stride != 1:
+            img = F.interpolate(
+                img, size=(H // self.output_stride, W // self.output_stride),
+                mode="bilinear", align_corners=False,
+            )
+
+        x = self.fourier_feat(img)
+        x = self.first_conv(x)
+        B, Ch, Hout, Wout = x.shape
+        x = x.flatten(2).transpose(-1, -2)  # [B, Hout*Wout, Ch]
+
+        lr_pe = self.lr_pe(lr_feats_2d)
+        lr_feats_pe = torch.cat([lr_feats_2d, lr_pe], dim=1)
+        lr_feats_pe = lr_feats_pe.flatten(2).permute(0, 2, 1)
+
+        lr_feats_pe = self.lr_input_proj(lr_feats_pe)  # [B, ph*pw, dim]
+
+        for blk in self.ca_transformer_blocks:
+            x = blk(x, lr_feats_pe)
+        x = self.ca_transformer_norm(x)
+
+        x = x.transpose(-1, -2).reshape(B, Ch, Hout, Wout)
+
+        return None, x

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/mask_transformer.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/mask_transformer.py
@@ -1,0 +1,361 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 multi-view mask transformer.
+
+The decoder uses learned object queries and normalized 2D sine positional
+encoding only. The same spatial positional encoding is repeated for every
+view, so there is no learned ordinal frame table and no view-count-dependent
+3D coordinate system.
+"""
+
+import math
+import torch
+from torch import nn, Tensor
+import torch.nn.functional as F
+from typing import Optional, List
+
+from nvidia_tao_pytorch.cv.mask2former.model.transformer_decoder.position_encoding import (
+    PositionEmbeddingSine,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.transformer_decoder.joint_depth_transformer_decoder import (
+    FFNLayer,
+    MLP,
+    SelfAttentionLayer,
+)
+
+
+class CrossAttentionLayer(nn.Module):
+    """Visual cross-attention with normalized 2D positional encoding only.
+
+    Separate projections keep visual attention explicit and avoid
+    geometry-specific parameters. The residual is post-normalized.
+    """
+
+    def __init__(self, d_model: int, nhead: int, dropout: float = 0.0):
+        super().__init__()
+        self.d_model = d_model
+        self.nhead = nhead
+        self.head_dim = d_model // nhead
+
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.k_proj = nn.Linear(d_model, d_model)
+        self.v_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+
+        self.norm = nn.LayerNorm(d_model)
+        self.dropout = nn.Dropout(dropout)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Initialize matrix parameters with Xavier-uniform weights."""
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(
+        self,
+        tgt: Tensor,
+        memory: Tensor,
+        memory_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Args:
+            tgt:       [Q, B, C]   query tokens
+            memory:    [L, B, C]   key/value tokens (frame features)
+            memory_mask: optional attention mask
+            pos:       [L, B, C]   2D sinusoidal PE for keys
+            query_pos: [Q, B, C]   PE for queries
+        """
+        residual = tgt
+
+        q = self.q_proj(tgt + query_pos if query_pos is not None else tgt)
+        k = self.k_proj(memory + pos if pos is not None else memory)
+        v = self.v_proj(memory)
+
+        Q, B, _ = q.shape
+        L = k.shape[0]
+
+        q = q.permute(1, 0, 2).reshape(B, Q, self.nhead, self.head_dim).permute(0, 2, 1, 3)
+        k = k.permute(1, 0, 2).reshape(B, L, self.nhead, self.head_dim).permute(0, 2, 1, 3)
+        v = v.permute(1, 0, 2).reshape(B, L, self.nhead, self.head_dim).permute(0, 2, 1, 3)
+
+        scale = math.sqrt(self.head_dim)
+        attn_weights = torch.matmul(q, k.transpose(-2, -1)) / scale
+
+        if memory_mask is not None:
+            if memory_mask.dim() == 2:
+                attn_weights = attn_weights.masked_fill(memory_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+            elif memory_mask.dim() == 3:
+                attn_weights = attn_weights.masked_fill(memory_mask.unsqueeze(1), float("-inf"))
+            elif memory_mask.dim() == 4:
+                attn_weights = attn_weights.masked_fill(memory_mask, float("-inf"))
+            else:
+                attn_weights = attn_weights + memory_mask
+
+        if memory_key_padding_mask is not None:
+            attn_weights = attn_weights.masked_fill(
+                memory_key_padding_mask[:, None, None, :], float("-inf")
+            )
+
+        # FP32 normalization is more stable for 20/50-view inference, where
+        # the attention denominator spans tens of thousands of tokens.
+        attn_weights = F.softmax(attn_weights.float(), dim=-1).to(v.dtype)
+        attn_weights = self.dropout(attn_weights)
+
+        out = torch.matmul(attn_weights, v)
+        out = out.permute(0, 2, 1, 3).reshape(B, Q, self.d_model).permute(1, 0, 2)
+
+        out = self.out_proj(out)
+        return self.norm(residual + self.dropout(out))
+
+
+# Visual-only multi-view decoder
+
+class NVPanoptix3Dv2MaskTransformer(nn.Module):
+    """Multi-view Mask2Former decoder with learned object queries.
+
+    Cross-attention uses normalized 2D sine PE only. Spatial PE is repeated
+    across views; there is no frame table, 3D PE, presence token, or
+    geometry-based query initialization. A vocabulary-independent objectness
+    head optionally separates matched/unmatched confidence from class scores.
+    """
+
+    def __init__(
+        self,
+        in_dim,
+        hidden_dim: int = 768,
+        ff_dim: int = 2048,
+        mask_dim: int = 384,
+        num_queries: int = 200,
+        num_heads: int = 8,
+        dec_layers: int = 6,
+        lang_dim: int = 768,
+        num_feature_levels: int = 1,
+        enable_objectness: bool = False,
+    ):
+        super().__init__()
+        self.num_feature_levels = num_feature_levels
+        if isinstance(in_dim, int):
+            in_dim = [in_dim] * num_feature_levels
+
+        N_steps = hidden_dim // 2
+        self.pe_layer = PositionEmbeddingSine(N_steps, normalize=True)
+
+        self.num_heads = num_heads
+        self.num_layers = dec_layers
+        self.enable_objectness = enable_objectness
+
+        self.self_attn_layers = nn.ModuleList()
+        self.cross_attn_layers = nn.ModuleList()
+        self.ffn_layers = nn.ModuleList()
+        for _ in range(dec_layers):
+            self.self_attn_layers.append(SelfAttentionLayer(d_model=hidden_dim, nhead=num_heads, dropout=0.0))
+            self.cross_attn_layers.append(
+                CrossAttentionLayer(
+                    d_model=hidden_dim,
+                    nhead=num_heads,
+                    dropout=0.0,
+                )
+            )
+            self.ffn_layers.append(FFNLayer(d_model=hidden_dim, dim_feedforward=ff_dim, dropout=0.0))
+
+        self.decoder_norm = nn.LayerNorm(hidden_dim)
+
+        # Learnable Mask2Former queries.
+        self.query_feat = nn.Embedding(num_queries, hidden_dim)
+        self.query_embed = nn.Embedding(num_queries, hidden_dim)
+
+        self.level_embed = nn.Embedding(num_feature_levels, hidden_dim)
+
+        self.input_proj = nn.ModuleList()
+        for d in in_dim:
+            if d != hidden_dim:
+                proj = nn.Conv2d(d, hidden_dim, kernel_size=1)
+                nn.init.xavier_normal_(proj.weight)
+                self.input_proj.append(proj)
+            else:
+                self.input_proj.append(nn.Sequential())
+
+        self.lang_embed = nn.Linear(hidden_dim, lang_dim)
+        self.cls_logit_scale = nn.Parameter(torch.ones([]))
+        self.mask_embed = MLP(hidden_dim, hidden_dim, mask_dim, 3)
+
+        # Vocabulary-independent matched/unmatched confidence. Semantic
+        # cosine similarity alone is not objectness: an unmatched query can
+        # still be close to some text embedding. Keep the two decisions
+        # separate so inference can rank by p(object) * p(class | object).
+        if self.enable_objectness:
+            self.objectness_embed = nn.Linear(hidden_dim, 1)
+            nn.init.xavier_uniform_(self.objectness_embed.weight)
+            # Start from a conservative 10% object prior for 200 queries.
+            nn.init.constant_(self.objectness_embed.bias, -math.log(9.0))
+
+    def build_view_position_encoding(
+        self,
+        spatial_pos: torch.Tensor,
+        n_views: int,
+    ) -> torch.Tensor:
+        """Tile the same spatial positional encoding across views."""
+        return spatial_pos.repeat(n_views, 1, 1)
+
+    def build_spatial_position_encoding(self, feature_map: torch.Tensor) -> torch.Tensor:
+        """Encode the feature map in its actual ``(H, W)`` orientation.
+
+        VGGT patch tokens are already laid out in the input tensor's native
+        orientation. Transposing only the positional grid for portrait inputs
+        changes its flattened token order and assigns positions to the wrong
+        visual tokens.
+        """
+        return self.pe_layer(feature_map, None).flatten(2).permute(2, 0, 1)
+
+    def forward(
+        self,
+        fpn_f: List[torch.Tensor],
+        mask_feats: torch.Tensor,
+        cls_embeddings: torch.Tensor,
+        deep_supervision: bool = True,
+        outdevice: Optional[torch.device] = None,
+    ):
+        """Decode object queries against the fused multi-view memory."""
+        if len(fpn_f) != self.num_feature_levels:
+            raise ValueError(
+                f"Expected {self.num_feature_levels} feature levels, got {len(fpn_f)}"
+            )
+        if outdevice is None:
+            outdevice = mask_feats.device
+
+        src = []
+        pos = []
+        size_list = []
+
+        for i in range(self.num_feature_levels):
+            B, N, _, _, _ = fpn_f[i].shape
+            size_list.append(fpn_f[i].shape[-2:])
+            pos_i = self.build_spatial_position_encoding(fpn_f[i][:, 0])
+            pos.append(self.build_view_position_encoding(pos_i, N))
+
+            src_i = self.input_proj[i](fpn_f[i][:, :N].permute(0, 2, 1, 3, 4).flatten(-3))
+            src.append(src_i.permute(2, 0, 1) + self.level_embed.weight[i][None, None])
+
+        output = self.query_feat.weight.unsqueeze(1).expand(-1, B, -1)
+        query_embed = self.query_embed.weight.unsqueeze(1).expand(-1, B, -1)
+
+        outputs_class, outputs_masks, outputs_objectness, attn_mask = self.forward_prediction_heads(
+            output, mask_feats, cls_embeddings, attn_mask_target_size=size_list[0], outdevice=outdevice
+        )
+
+        predictions_class = []
+        predictions_masks = []
+        predictions_objectness = []
+        if deep_supervision:
+            predictions_class.append(outputs_class)
+            predictions_masks.append(outputs_masks)
+            predictions_objectness.append(outputs_objectness)
+
+        for i in range(self.num_layers):
+            level_index = i % self.num_feature_levels
+            attn_mask[torch.where(attn_mask.sum(-1) == attn_mask.shape[-1])] = False
+
+            output = self.cross_attn_layers[i](
+                output, src[level_index],
+                memory_mask=attn_mask,
+                pos=pos[level_index],
+                query_pos=query_embed,
+            )
+
+            output = self.self_attn_layers[i](
+                output, tgt_mask=None, tgt_key_padding_mask=None, query_pos=query_embed,
+            )
+
+            output = self.ffn_layers[i](output)
+
+            outputs_class, outputs_masks, outputs_objectness, attn_mask = self.forward_prediction_heads(
+                output, mask_feats, cls_embeddings,
+                attn_mask_target_size=size_list[(i + 1) % self.num_feature_levels],
+                outdevice=outdevice,
+            )
+
+            if deep_supervision or i >= self.num_layers - 1:
+                predictions_class.append(outputs_class)
+                predictions_masks.append(outputs_masks)
+                predictions_objectness.append(outputs_objectness)
+
+        out = {
+            "pred_logits": predictions_class[-1],
+            "pred_masks": predictions_masks[-1],
+            "pred_objectness": predictions_objectness[-1],
+            "aux_outputs": [
+                {
+                    "pred_logits": c,
+                    "pred_masks": m,
+                    "pred_objectness": o,
+                }
+                for c, m, o in zip(
+                    predictions_class[:-1],
+                    predictions_masks[:-1],
+                    predictions_objectness[:-1],
+                )
+            ],
+            "out_queries": output.detach(),
+        }
+        return out
+
+    def forward_prediction_heads(
+        self,
+        output: Tensor,
+        mask_feats: Tensor,
+        cls_embeddings: Tensor,
+        attn_mask_target_size=None,
+        outdevice=None,
+    ):
+        """Produce the per-layer class logits, mask logits and attention mask."""
+        if outdevice is None:
+            outdevice = mask_feats.device
+
+        decoder_output = self.decoder_norm(output).transpose(0, 1)
+
+        # This normalized projection is an internal classifier feature. It is
+        # not returned because the current objective has no contrastive
+        # query/text loss; class logits are its only consumer.
+        class_query_embed = self.lang_embed(decoder_output)
+        class_query_embed = class_query_embed / (
+            class_query_embed.norm(dim=-1, keepdim=True) + 1e-7
+        )
+        outputs_class = (
+            self.cls_logit_scale.exp() *
+            class_query_embed
+            @ cls_embeddings.unsqueeze(0).transpose(1, 2)
+        ).to(outdevice)
+
+        outputs_objectness = None
+        if self.enable_objectness:
+            outputs_objectness = self.objectness_embed(decoder_output).squeeze(-1)
+            outputs_objectness = outputs_objectness.to(outdevice)
+
+        mask_embed = self.mask_embed(decoder_output)
+        mask_embed = mask_embed.unsqueeze(1).expand(-1, mask_feats.shape[1], -1, -1)
+
+        outputs_mask = torch.einsum("bnqc,bnchw->bnqhw", mask_embed, mask_feats)
+
+        attn_mask = None
+        if attn_mask_target_size is not None:
+            B, N_v, Q, _, _ = outputs_mask.shape
+            attn_mask = outputs_mask.flatten(0, 1)
+            attn_mask = F.interpolate(
+                attn_mask, size=attn_mask_target_size, mode="bilinear", align_corners=False
+            )
+            attn_mask = attn_mask.view(B, N_v, Q, *attn_mask_target_size)
+            attn_mask = attn_mask.permute(0, 2, 1, 3, 4).flatten(-3)
+            attn_mask = (attn_mask.sigmoid().unsqueeze(1).repeat(1, self.num_heads, 1, 1) < 0.5).bool()
+
+        return (
+            outputs_class,
+            outputs_mask.to(outdevice),
+            outputs_objectness,
+            attn_mask,
+        )

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/panoptic_decoder.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/panoptic_decoder.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 panoptic segmentation head over VGGT features.
+
+Components:
+  - DINO + VGGT concatenation and a three-block per-view spatial mixer
+  - one native stride-14 cross-attention memory
+  - LoftUp upscaler for stride-2 mask features
+  - mask transformer with normalized 2D sine positional encoding
+  - text encoder for open-vocabulary classification
+"""
+
+from typing import Dict, List, Optional
+
+import torch
+from torch import nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.feature_fusion import (
+    ConcatenatedFeatureFusion,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.mask_transformer import (
+    NVPanoptix3Dv2MaskTransformer,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.text_encoder import (
+    TextEncoder,
+)
+
+
+class NVPanoptix3Dv2PanopticDecoder(nn.Module):
+    """
+    Panoptic segmentation decoder for NVPanoptix3Dv2.
+
+    Every decoder layer attends to the same native stride-14 fused token map.
+    High-resolution spatial detail enters mask prediction through LoftUp's
+    RGB-guided stride-2 mask features, not a synthetic cross-attention FPN.
+    """
+
+    def __init__(
+        self,
+        feature_fusion: ConcatenatedFeatureFusion,
+        upscaler: nn.Module,
+        hidden_dim: int = 768,
+        mask_dim: int = 384,
+        ff_dim: int = 2048,
+        num_queries: int = 200,
+        num_heads: int = 8,
+        dec_layers: int = 6,
+        fixed_vocab: bool = True,
+        label_mode: str = "sigmoid",
+        deep_supervision: bool = True,
+        patch_size: int = 14,
+        enable_objectness: bool = False,
+    ):
+        super().__init__()
+
+        self.feature_fusion = feature_fusion
+        self.upscaler = upscaler
+        self.patch_size = patch_size
+        self.deep_supervision = deep_supervision
+        self.label_mode = label_mode
+        self.text_encoder = TextEncoder(fixed_vocab=fixed_vocab)
+
+        if self.label_mode == "softmax":
+            self.nocls_token = nn.Parameter(torch.randn(self.text_encoder.embed_dim))
+
+        self.mask_transformer = NVPanoptix3Dv2MaskTransformer(
+            in_dim=hidden_dim,
+            hidden_dim=hidden_dim,
+            ff_dim=ff_dim,
+            mask_dim=mask_dim,
+            num_queries=num_queries,
+            num_heads=num_heads,
+            dec_layers=dec_layers,
+            lang_dim=self.text_encoder.embed_dim,
+            num_feature_levels=1,
+            enable_objectness=enable_objectness,
+        )
+
+    def forward(
+        self,
+        dino_feats: torch.Tensor,
+        vggt_feats: torch.Tensor,
+        images: torch.Tensor,
+        classes: List[str],
+        outdevice: Optional[torch.device] = None,
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Args:
+            dino_feats:        [B, S, P, C_dino]      DINOv2 patch features
+            vggt_feats:        [B, S, P, C_vggt]      VGGT final AA features
+            images:            [B, S, 3, H, W]        input images
+            classes:           list of class names
+
+        Returns:
+            dict with pred_logits, pred_masks, aux_outputs, out_queries
+        """
+        B, S, P, _ = dino_feats.shape
+        H, W = images.shape[-2:]
+        if H % self.patch_size != 0 or W % self.patch_size != 0:
+            raise ValueError(
+                f"Image shape {(H, W)} must be divisible by patch_size="
+                f"{self.patch_size}"
+            )
+        patch_h = H // self.patch_size
+        patch_w = W // self.patch_size
+        expected_patches = patch_h * patch_w
+        if P != expected_patches or vggt_feats.shape[2] != expected_patches:
+            raise ValueError(
+                "Backbone token counts do not match the input orientation: "
+                f"DINO P={P}, VGGT P={vggt_feats.shape[2]}, expected "
+                f"{patch_h}*{patch_w}={expected_patches} for {(H, W)}"
+            )
+
+        # Vocabulary-independent visual feature fusion
+        dino_flat = dino_feats.reshape(B * S, P, -1)
+        vggt_flat = vggt_feats.reshape(B * S, P, -1)
+        fused = self.feature_fusion(
+            dino_flat,
+            vggt_flat,
+            spatial_shape=(patch_h, patch_w),
+        )
+        fused = fused.reshape(B, S, P, -1)
+
+        # --- Text embeddings (classification head only; visual features are
+        # never conditioned on the vocabulary)
+        cls_embeddings = self.text_encoder(classes)
+        cls_embeddings = cls_embeddings.to(fused.device)
+        if self.label_mode == "softmax":
+            cls_embeddings = torch.cat([cls_embeddings, self.nocls_token[None]], dim=0)
+
+        # One native stride-14 cross-attention level
+        C = fused.shape[-1]
+        native = fused.reshape(B, S, patch_h, patch_w, C).permute(0, 1, 4, 2, 3)
+        fpn = [native]
+
+        # Upscaler: fused tokens + images -> high-res mask features
+        fused_per_view = fused.reshape(B * S, P, -1)
+        imgs_per_view = images.reshape(B * S, *images.shape[2:])
+        _, mask_feats = self.upscaler(
+            (fused_per_view, imgs_per_view),
+            (H, W),
+        )
+        mC, mH, mW = mask_feats.shape[1:]
+        mask_feats = mask_feats.reshape(B, S, mC, mH, mW)
+
+        # Multi-view mask transformer with normalized 2D sine PE only.
+        pan_out = self.mask_transformer(
+            fpn,
+            mask_feats,
+            cls_embeddings,
+            deep_supervision=self.deep_supervision,
+            outdevice=outdevice,
+        )
+
+        return pan_out

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/panoptic_model.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/panoptic_model.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Joint 3D reconstruction and open-vocabulary panoptic segmentation.
+
+A feed-forward model over unposed multi-view images. VGGT is the 3D backbone;
+its tokens are concatenated with DINOv2's, projected, and refined by a
+three-block per-view spatial mixer. The decoder reads one native stride-14
+memory plus stride-2 LoftUp mask features, and a metric scale head converts
+VGGT's normalised depth to metric.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import torch
+from torch import nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.metric_scale_head import (
+    MetricScaleHead,
+    apply_metric_scale,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.panoptic_decoder import (
+    NVPanoptix3Dv2PanopticDecoder,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt import VGGT
+
+
+class NVPanoptix3Dv2Panoptic(nn.Module):
+    """
+    Main NVPanoptix3Dv2 model.
+
+    Combines a VGGT backbone (3D reconstruction + multi-scale features) with a
+    multi-view panoptic segmentation decoder.
+
+    Forward pipeline:
+      1. VGGT Backbone -> DINOv2 feats, VGGT feats, depth, 3D points, cameras
+      2. PanopticDecoder -> concat projection -> spatial mixer -> LoftUp ->
+         2D-PE Mask Transformer
+      3. MetricScaleHead(first 5 views) -> one scene scale,
+         applied to metric depth and world points for every view
+    """
+
+    def __init__(
+        self,
+        vggt_backbone: VGGT,
+        panoptic_decoder: NVPanoptix3Dv2PanopticDecoder,
+        metric_depth_head: Optional[MetricScaleHead] = None,
+    ):
+        super().__init__()
+
+        self.vggt_backbone = vggt_backbone
+        self.panoptic_decoder = panoptic_decoder
+        self.metric_depth_head = metric_depth_head
+
+    def freeze_vggt_weights(self):
+        """Freeze the complete VGGT backbone."""
+        for param in self.vggt_backbone.parameters():
+            param.requires_grad = False
+
+    def forward(
+        self,
+        images: torch.Tensor,
+        true_shape: torch.Tensor,
+        classes: List[str],
+        outdevice: Optional[torch.device] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+        """
+        Args:
+            images:     [B, S, 3, H, W]  input images in [0, 1]
+            true_shape: [B, S, 2]         compatibility metadata; spatial
+                                          layout comes from ``images``
+            classes:    list of class names for open-vocabulary prediction
+            outdevice:  optional target device for outputs
+
+        Returns:
+            (panoptic_output, geometry_output)
+
+            panoptic_output:
+              pred_logits:  [B, Q, C]       class predictions
+              pred_masks:   [B, S, Q, H, W] mask predictions
+              aux_outputs:  list of intermediate predictions
+
+            geometry_output:
+              depth:            [B, S, H, W, 1]   relative (normalised) depth
+              depth_conf:       [B, S, H, W]
+              world_points:     [B, S, H, W, 3]   normalised world points (from frozen point_head)
+              world_points_conf:[B, S, H, W]
+              pose_enc:         [B, S, 9]
+              metric_scale_params: dict with ``log_s``, ``scale``, ``intrinsics``
+                                   (if metric_depth_head is enabled)
+              metric_depth:       [B, S, H, W, 1]   (if metric_depth_head) — corrected
+              metric_points:      [B, S, H, W, 3]   (if metric_depth_head) — scaled world_points
+              intrinsics:         [B, S, 3, 3]      reconstructed intrinsics (metric scale)
+        """
+        expected_shape = (images.shape[0], images.shape[1], 2)
+        if tuple(true_shape.shape) != expected_shape:
+            raise ValueError(
+                f"true_shape must have shape {expected_shape}, got "
+                f"{tuple(true_shape.shape)}"
+            )
+
+        backbone_out = self.vggt_backbone(images)
+
+        dino_feats = backbone_out["dino_feats"]
+        vggt_feats = backbone_out["vggt_feats"]
+        depth = backbone_out.get("depth")
+        world_points = backbone_out.get("world_points")
+
+        panout = self.panoptic_decoder(
+            dino_feats=dino_feats,
+            vggt_feats=vggt_feats,
+            images=images,
+            classes=classes,
+            outdevice=outdevice,
+        )
+
+        geometry_output = {
+            k: backbone_out[k]
+            for k in ("depth", "depth_conf", "world_points", "world_points_conf", "pose_enc")
+            if k in backbone_out
+        }
+
+        if self.metric_depth_head is not None and depth is not None:
+            pose_enc = backbone_out.get("pose_enc")
+            if pose_enc is not None:
+                _, _, H_d, W_d, _ = depth.shape
+
+                metric_scale_params = self.metric_depth_head(
+                    vggt_feats=vggt_feats,
+                    rel_depth=depth,
+                    pose_enc=pose_enc,
+                    image_size_hw=(H_d, W_d),
+                )
+                scale = metric_scale_params["scale"]  # [B, 1]
+
+                geometry_output["metric_scale_params"] = metric_scale_params
+                geometry_output["intrinsics"] = metric_scale_params["intrinsics"]
+
+                # The head estimates one scene-level scale correction from
+                # its fixed five-view context. Apply it to every view,
+                # including views outside that context at inference.
+                metric_depth = apply_metric_scale(depth, metric_scale_params)
+                geometry_output["metric_depth"] = metric_depth
+
+                # Scale VGGT's globally-aligned world_points to metric.
+                # VGGT's point_head produces multi-view-consistent points in a
+                # shared coordinate frame; applying the same predicted scale
+                # to depth and points keeps both metric outputs consistent.
+                if world_points is not None:
+                    metric_points = world_points * scale[:, :, None, None, None]
+                    geometry_output["metric_points"] = metric_points
+
+        return panout, geometry_output
+
+    def set_vocab(self, class_names: List[str], device=None):
+        """Pre-compute text embeddings for a fixed class vocabulary."""
+        self.panoptic_decoder.text_encoder.set_vocab(class_names, device=device)

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/pl_model.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/pl_model.py
@@ -1,0 +1,862 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 PyTorch Lightning Module."""
+
+import json
+import logging
+import math
+import os
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import Callback, ModelCheckpoint
+
+from nvidia_tao_pytorch.core.lightning.tao_lightning_module import TAOLightningModule
+from nvidia_tao_pytorch.core.callbacks.loggers import TAOStatusLogger
+from nvidia_tao_pytorch.core.callbacks.model_checkpoint import TAOExceptionCheckpoint
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.panoptic_model import NVPanoptix3Dv2Panoptic
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models.vggt import VGGT
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.feature_fusion import ConcatenatedFeatureFusion
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.panoptic_decoder import NVPanoptix3Dv2PanopticDecoder
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.loftup import LoftUpUpscaler
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.metric_scale_head import MetricScaleHead
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.losses import NVPanoptix3Dv2PanopticLoss
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.engine_eval import panoptic_inference
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.mAP import (
+    evaluate_instance_map_segvggt,
+    prepare_instance_map_sample,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_DECAY_WEIGHT_MODULES = (
+    torch.nn.Linear,
+    torch.nn.Conv1d,
+    torch.nn.Conv2d,
+    torch.nn.Conv3d,
+    torch.nn.ConvTranspose1d,
+    torch.nn.ConvTranspose2d,
+    torch.nn.ConvTranspose3d,
+    torch.nn.MultiheadAttention,
+)
+
+
+def adamw_parameter_groups(
+    module: torch.nn.Module,
+    lr: float,
+    weight_decay: float,
+    component_name: str,
+):
+    """Split one component into strict decay and no-decay AdamW groups.
+
+    Decay is applied only to matrix/conv weights. Everything else—including
+    normalization parameters, biases, scalar temperatures, nn.Embedding
+    tables, and free positional embeddings—has zero weight decay.
+    """
+    decay_parameter_ids = set()
+    for submodule in module.modules():
+        if not isinstance(submodule, _DECAY_WEIGHT_MODULES):
+            continue
+        for parameter_name, parameter in submodule.named_parameters(
+            recurse=False,
+        ):
+            if parameter_name.endswith("weight") and parameter.ndim >= 2:
+                decay_parameter_ids.add(id(parameter))
+
+    decay_parameters = []
+    no_decay_parameters = []
+    for _, parameter in module.named_parameters():
+        if not parameter.requires_grad:
+            continue
+        if id(parameter) in decay_parameter_ids:
+            decay_parameters.append(parameter)
+        else:
+            no_decay_parameters.append(parameter)
+
+    groups = []
+    if decay_parameters:
+        groups.append({
+            "params": decay_parameters,
+            "lr": lr,
+            "lr_scale": 1.0,
+            "weight_decay": weight_decay,
+            "group_name": f"{component_name}_decay",
+        })
+    if no_decay_parameters:
+        groups.append({
+            "params": no_decay_parameters,
+            "lr": lr,
+            "lr_scale": 1.0,
+            "weight_decay": 0.0,
+            "group_name": f"{component_name}_no_decay",
+        })
+    return groups
+
+
+def get_cfg_val(cfg, key, default=None):
+    """Helper to get value from OmegaConf or dict."""
+    if hasattr(cfg, key):
+        return getattr(cfg, key)
+    if isinstance(cfg, dict):
+        return cfg.get(key, default)
+    return default
+
+
+def build_vggt(cfg) -> VGGT:
+    """Load pretrained VGGT model from config."""
+    model_cfg = cfg.model if hasattr(cfg, "model") else cfg["model"]
+    backbone_cfg = get_cfg_val(model_cfg, "backbone", {})
+    vggt_ckpt = get_cfg_val(backbone_cfg, "pretrained_backbone_path", None)
+
+    img_size = model_cfg.img_size if hasattr(model_cfg, "img_size") else model_cfg["img_size"]
+    patch_size = model_cfg.patch_size if hasattr(model_cfg, "patch_size") else model_cfg["patch_size"]
+    embed_dim = model_cfg.embed_dim if hasattr(model_cfg, "embed_dim") else model_cfg["embed_dim"]
+
+    model_kwargs = {
+        "img_size": img_size,
+        "patch_size": patch_size,
+        "embed_dim": embed_dim,
+    }
+
+    if vggt_ckpt and os.path.exists(vggt_ckpt):
+        # The point-tracking head is not vendored (neither variant tracks
+        # points), so drop its weights before the strict load and the remaining
+        # keys still verify exactly.
+        vggt = VGGT(**model_kwargs)
+        state_dict = torch.load(vggt_ckpt, map_location="cpu", weights_only=False)
+        if isinstance(state_dict, dict) and "state_dict" in state_dict:
+            state_dict = state_dict["state_dict"]
+        if isinstance(state_dict, dict) and "model" in state_dict \
+                and isinstance(state_dict["model"], dict):
+            state_dict = state_dict["model"]
+        state_dict = {
+            key: value for key, value in state_dict.items()
+            if not key.startswith("track_head.")
+        }
+        strict = bool(get_cfg_val(backbone_cfg, "strict_load", True))
+        incompatible = vggt.load_state_dict(state_dict, strict=strict)
+        if not strict and (incompatible.missing_keys or incompatible.unexpected_keys):
+            logger.warning(
+                "VGGT checkpoint loaded non-strictly: %d missing keys, %d unexpected keys",
+                len(incompatible.missing_keys), len(incompatible.unexpected_keys),
+            )
+    elif bool(get_cfg_val(backbone_cfg, "load_from_hf", False)):
+        vggt = VGGT.from_pretrained("facebook/VGGT-1B", **model_kwargs)
+    else:
+        raise FileNotFoundError(
+            f"VGGT checkpoint not found at {vggt_ckpt!r}; set "
+            "model.backbone.pretrained_backbone_path or enable "
+            "model.backbone.load_from_hf."
+        )
+    return vggt
+
+
+def build_model_from_config(cfg) -> NVPanoptix3Dv2Panoptic:
+    """Build the complete NVPanoptix3Dv2 model from experiment config."""
+    model_cfg = cfg.model if hasattr(cfg, "model") else cfg["model"]
+    variant_cfg = get_cfg_val(model_cfg, "panoptic", {})
+
+    vggt = build_vggt(cfg)
+
+    fusion_cfg = get_cfg_val(variant_cfg, "feature_fusion", {})
+    feature_fusion = ConcatenatedFeatureFusion(
+        dino_dim=get_cfg_val(fusion_cfg, "dino_dim", 1024),
+        vggt_dim=get_cfg_val(fusion_cfg, "vggt_dim", 2048),
+        hidden_dim=get_cfg_val(fusion_cfg, "hidden_dim", 768),
+        num_heads=get_cfg_val(fusion_cfg, "num_heads", 12),
+        num_layers=get_cfg_val(fusion_cfg, "num_layers", 3),
+        ff_dim_mult=get_cfg_val(fusion_cfg, "ff_dim_mult", 4),
+    )
+
+    up_cfg = get_cfg_val(variant_cfg, "upscaler")
+    upscaler = LoftUpUpscaler(
+        input_dim=get_cfg_val(up_cfg, "input_dim", 768),
+        dim=get_cfg_val(up_cfg, "dim", 384),
+        output_stride=get_cfg_val(up_cfg, "output_stride", 2),
+        patch_size=get_cfg_val(up_cfg, "patch_size", 14),
+        color_feats=get_cfg_val(up_cfg, "color_feats", True),
+        n_freqs=get_cfg_val(up_cfg, "n_freqs", 20),
+        num_heads=get_cfg_val(up_cfg, "num_heads", 4),
+        num_layers=get_cfg_val(up_cfg, "num_layers", 2),
+    )
+
+    pd_cfg = get_cfg_val(variant_cfg, "panoptic_decoder")
+
+    panoptic_decoder = NVPanoptix3Dv2PanopticDecoder(
+        feature_fusion=feature_fusion,
+        upscaler=upscaler,
+        hidden_dim=get_cfg_val(pd_cfg, "hidden_dim", 768),
+        mask_dim=get_cfg_val(pd_cfg, "mask_dim", 384),
+        ff_dim=get_cfg_val(pd_cfg, "ff_dim", 2048),
+        num_queries=get_cfg_val(pd_cfg, "num_queries", 200),
+        num_heads=get_cfg_val(pd_cfg, "num_heads", 8),
+        dec_layers=get_cfg_val(pd_cfg, "dec_layers", 6),
+        fixed_vocab=get_cfg_val(pd_cfg, "fixed_vocab", True),
+        label_mode=get_cfg_val(pd_cfg, "label_mode", "sigmoid"),
+        deep_supervision=get_cfg_val(pd_cfg, "deep_supervision", True),
+        patch_size=get_cfg_val(model_cfg, "patch_size", 14),
+        enable_objectness=bool(get_cfg_val(pd_cfg, "enable_objectness", True)),
+    )
+
+    backbone_cfg = get_cfg_val(model_cfg, "backbone", {})
+    depth_head_cfg = get_cfg_val(backbone_cfg, "metric_depth_head", None)
+    metric_depth_head = None
+    if depth_head_cfg is not None and get_cfg_val(depth_head_cfg, "enable", True):
+        hidden_dims = get_cfg_val(depth_head_cfg, "hidden_dims", None)
+        if hidden_dims is None:
+            # Back-compat: a single ``hidden_dim`` int collapses to ``[h, h//4]``.
+            h = get_cfg_val(depth_head_cfg, "hidden_dim", 256)
+            hidden_dims = [h, max(h // 4, 16)]
+        metric_depth_head = MetricScaleHead(
+            scene_token_dim=get_cfg_val(depth_head_cfg, "feat_dim", 2048),
+            hidden_dims=tuple(hidden_dims),
+            metric_context_views=int(
+                get_cfg_val(depth_head_cfg, "metric_context_views", 5)
+            ),
+            # Panoptic metric depth is deliberately scale-only. Reasoning uses
+            # the shared config's scale-plus-shift default.
+            predict_shift=False,
+        )
+        logger.info(
+            "MetricScaleHead enabled (%d params, context_views=%d, predict_shift=%s)",
+            sum(p.numel() for p in metric_depth_head.parameters()),
+            metric_depth_head.metric_context_views,
+            metric_depth_head.predict_shift,
+        )
+
+    model = NVPanoptix3Dv2Panoptic(
+        vggt_backbone=vggt,
+        panoptic_decoder=panoptic_decoder,
+        metric_depth_head=metric_depth_head,
+    )
+
+    return model
+
+
+def build_criterion_from_config(cfg) -> NVPanoptix3Dv2PanopticLoss:
+    """Build the loss module from experiment config."""
+    train_cfg = cfg.train if hasattr(cfg, "train") else cfg["train"]
+    model_cfg = cfg.model if hasattr(cfg, "model") else cfg["model"]
+    pd_cfg = get_cfg_val(get_cfg_val(model_cfg, "panoptic", {}), "panoptic_decoder")
+
+    loss_cfg = get_cfg_val(train_cfg, "panoptic", {})
+    metric_cfg = get_cfg_val(train_cfg, "metric_depth", {})
+
+    return NVPanoptix3Dv2PanopticLoss(
+        dec_layers=get_cfg_val(pd_cfg, "dec_layers", 6),
+        deep_supervision=get_cfg_val(pd_cfg, "deep_supervision", True),
+        class_weight=get_cfg_val(loss_cfg, "class_weight", 2.0),
+        rank_weight=get_cfg_val(loss_cfg, "rank_weight", 0.5),
+        objectness_weight=get_cfg_val(loss_cfg, "objectness_weight", 1.0),
+        objectness_no_object_weight=get_cfg_val(
+            loss_cfg, "objectness_no_object_weight", 0.1,
+        ),
+        objectness_ignore_overlap_threshold=get_cfg_val(
+            loss_cfg, "objectness_ignore_overlap_threshold", 0.5,
+        ),
+        mask_weight=get_cfg_val(loss_cfg, "mask_weight", 20.0),
+        dice_weight=get_cfg_val(loss_cfg, "dice_weight", 1.0),
+        num_points=get_cfg_val(loss_cfg, "num_loss_points", 12288),
+        label_mode=get_cfg_val(pd_cfg, "label_mode", "sigmoid"),
+        metric_depth_weight=get_cfg_val(metric_cfg, "weight", 5.0),
+        metric_silog_weight=get_cfg_val(metric_cfg, "silog_weight", 1.0),
+        metric_absrel_weight=get_cfg_val(metric_cfg, "absrel_weight", 0.1),
+        metric_silog_lambda=get_cfg_val(metric_cfg, "silog_lambda", 0.85),
+        metric_min_depth=get_cfg_val(metric_cfg, "min_depth", 0.1),
+        metric_max_depth=get_cfg_val(metric_cfg, "max_depth", 20.0),
+        # Decoupled Hungarian matching costs. ``None`` falls back to the
+        # corresponding ``*_weight`` for backward compat.
+    )
+
+
+class NVPanoptix3Dv2PanopticPlModule(TAOLightningModule):
+    """PyTorch Lightning module for NVPanoptix3Dv2 training and evaluation.
+
+    Inherits from TAOLightningModule to get:
+      - ModelCheckpoint (periodic saves every N steps + *_latest.pth symlink)
+      - TAOExceptionCheckpoint (saves on SLURM signal / exception for resume)
+      - TAOStatusLogger
+    """
+
+    def __init__(self, experiment_config):
+        """Initialize the module, its criterion, and the pretrained weights."""
+        super().__init__(experiment_config)
+        self.cfg = experiment_config
+        self.checkpoint_filename = 'nvpanoptix3d_v2_panoptic_model'
+        # Best-checkpoint selection ranks on instance-segmentation mAP.
+        self.monitor_metric = "val/mAP"
+        self.monitor_mode = "max"
+        self.train_cfg = experiment_config.train if hasattr(experiment_config, "train") else experiment_config["train"]
+
+        self.model = build_model_from_config(experiment_config)
+        self.criterion = build_criterion_from_config(experiment_config)
+
+        self.model.freeze_vggt_weights()
+
+        resume_ckpt = get_cfg_val(self.train_cfg, "resume_training_checkpoint_path", None)
+        has_resume = resume_ckpt and os.path.isfile(str(resume_ckpt))
+        if not has_resume:
+            results_dir = getattr(experiment_config, "results_dir", None)
+            if results_dir:
+                latest_link = os.path.join(str(results_dir), self.checkpoint_filename + "_latest.pth")
+                if os.path.exists(latest_link):
+                    has_resume = True
+
+        pretrained = get_cfg_val(self.train_cfg, "pretrained_model_path", None)
+        if pretrained and os.path.isfile(str(pretrained)) and not has_resume:
+            self.load_pretrained_weights(str(pretrained))
+        elif pretrained and has_resume:
+            logger.info("Skipping pretrained_model_path (resume checkpoint found; it takes priority)")
+        elif pretrained:
+            raise FileNotFoundError(
+                f"Panoptic pretrained_model_path does not exist: {pretrained}"
+            )
+
+        self.classes = None
+        self.eval_classes = None
+        self._eval_categories = None
+        self.eval_category_ids = None
+        self._vocab_set = False
+
+        eval_cfg = (
+            experiment_config.evaluate
+            if hasattr(experiment_config, "evaluate")
+            else experiment_config.get("evaluate", {})
+        )
+        self.cls_threshold = get_cfg_val(eval_cfg, "cls_threshold", 0.1)
+        self.mask_threshold = get_cfg_val(eval_cfg, "mask_threshold", 0.25)
+        self.overlap_threshold = get_cfg_val(eval_cfg, "overlap_threshold", 0.5)
+        inference_cfg = (
+            experiment_config.inference
+            if hasattr(experiment_config, "inference")
+            else experiment_config.get("inference", {})
+        )
+        self.inference_cls_threshold = get_cfg_val(
+            inference_cfg, "cls_threshold", 0.1,
+        )
+        self.inference_mask_threshold = get_cfg_val(
+            inference_cfg, "mask_threshold", 0.25,
+        )
+        self.inference_overlap_threshold = get_cfg_val(
+            inference_cfg, "overlap_threshold", 0.5,
+        )
+
+        # Compact per-sample intersection tables used for epoch-level AP.
+        self.all_map_samples = []
+
+        self._log_interval = get_cfg_val(self.train_cfg, "log_interval", 50)
+
+        total_params = sum(p.numel() for p in self.model.parameters())
+        trainable_params = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
+        logger.info(f"NVPanoptix3Dv2: {total_params / 1e6:.1f}M total params, {trainable_params / 1e6:.1f}M trainable")
+
+    def load_pretrained_weights(self, ckpt_path: str):
+        """Warm-start compatible model weights without optimizer state.
+
+        Parameters absent from the current model or having incompatible shapes
+        are skipped. Optimizer state, epoch counters, and schedules are not
+        restored.
+        """
+        logger.info("Loading pretrained weights from: %s", ckpt_path)
+        ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+
+        if "state_dict" in ckpt:
+            raw_sd = ckpt["state_dict"]
+            prefix = "model."
+            src_sd = {k[len(prefix):]: v for k, v in raw_sd.items() if k.startswith(prefix)}
+            if not src_sd:
+                src_sd = raw_sd
+            logger.info("  PL checkpoint (epoch=%s, step=%s)",
+                        ckpt.get("epoch", "?"), ckpt.get("global_step", "?"))
+        elif "model" in ckpt:
+            src_sd = ckpt["model"]
+        else:
+            src_sd = ckpt
+
+        dst_sd = self.model.state_dict()
+
+        compatible_sd = {}
+        loaded, skipped_shape, skipped_missing = [], [], []
+        for key, src_val in src_sd.items():
+            if key not in dst_sd:
+                skipped_missing.append(key)
+                continue
+            if src_val.shape != dst_sd[key].shape:
+                skipped_shape.append((key, tuple(src_val.shape), tuple(dst_sd[key].shape)))
+                continue
+            compatible_sd[key] = src_val
+            loaded.append(key)
+
+        # Missing parameters retain their current initialization.
+        load_result = self.model.load_state_dict(compatible_sd, strict=False)
+        new_only = list(load_result.missing_keys)
+
+        logger.info("  Loaded %d/%d params", len(loaded), len(dst_sd))
+        if skipped_shape:
+            logger.info("  Skipped %d params (shape mismatch):", len(skipped_shape))
+            for k, s_old, s_new in skipped_shape:
+                logger.info("    %s: %s -> %s", k, s_old, s_new)
+        if skipped_missing:
+            n_vggt = sum(1 for k in skipped_missing if k.startswith("vggt_backbone."))
+            n_other = len(skipped_missing) - n_vggt
+            if n_other > 0:
+                logger.info("  %d checkpoint keys not in model (dropped):", n_other)
+                for k in skipped_missing:
+                    if not k.startswith("vggt_backbone."):
+                        logger.info("    %s", k)
+        if new_only:
+            n_vggt = sum(1 for k in new_only if k.startswith("vggt_backbone."))
+            n_other = len(new_only) - n_vggt
+            if n_other > 0:
+                logger.info("  %d new model params (randomly initialised):", n_other)
+                for k in new_only:
+                    if not k.startswith("vggt_backbone."):
+                        logger.info("    %s", k)
+
+    def configure_callbacks(self) -> Sequence[Callback] | pl.Callback:
+        """Configure standard periodic, best, and exception checkpoints."""
+        results_dir = self.experiment_spec["results_dir"]
+        checkpoint_interval = self.experiment_spec["train"]["checkpoint_interval"]
+        checkpoint_interval_unit = self.experiment_spec["train"].get(
+            "checkpoint_interval_unit", "epoch",
+        )
+
+        status_logger_callback = TAOStatusLogger(results_dir, append=True)
+
+        ModelCheckpoint.FILE_EXTENSION = ".pth"
+        ModelCheckpoint.CHECKPOINT_EQUALS_CHAR = "_"
+
+        if not self.checkpoint_filename:
+            raise NotImplementedError("checkpoint_filename not set in __init__() of model")
+        ModelCheckpoint.CHECKPOINT_NAME_LAST = f"{self.checkpoint_filename}_latest"
+
+        checkpoint_callback = ModelCheckpoint(
+            every_n_epochs=(
+                checkpoint_interval if checkpoint_interval_unit == "epoch" else None
+            ),
+            every_n_train_steps=(
+                checkpoint_interval if checkpoint_interval_unit == "step" else None
+            ),
+            dirpath=results_dir,
+            save_on_train_epoch_end=True,
+            monitor=None,
+            save_top_k=-1,
+            save_last='link',
+            filename='model_{epoch:03d}_{step:06d}',
+            enable_version_counter=False,
+        )
+
+        TAOExceptionCheckpoint.FILE_EXTENSION = ModelCheckpoint.FILE_EXTENSION
+        TAOExceptionCheckpoint.CHECKPOINT_NAME_LAST = ModelCheckpoint.CHECKPOINT_NAME_LAST
+        exception_checkpoint_callback = TAOExceptionCheckpoint(dirpath=results_dir)
+
+        callbacks = [status_logger_callback, checkpoint_callback, exception_checkpoint_callback]
+
+        # Shared TAO top-k stream, ranked on val/mAP by this model's default or
+        # by an explicit train.checkpointer.monitor override.
+        callbacks = self._configure_best_checkpoint(callbacks, results_dir)
+
+        return callbacks
+
+    def set_classes(
+        self,
+        classes: List[str],
+        categories: Optional[List[Dict]] = None,
+    ):
+        """Set the class vocabulary for open-vocabulary prediction.
+
+        Args:
+            classes: bare class names. Indexed by ``pan_cls_id`` and used
+                as the canonical prediction vocabulary.
+            categories: optional list of category dicts with ``id``, ``name``,
+                and ``isthing`` fields. Instance mAP evaluates only categories
+                marked as things.
+        """
+        self.classes = list(classes)
+        self.eval_classes = list(classes)
+        self._eval_categories = categories
+        if self._eval_categories is None:
+            self.eval_category_ids = list(range(len(self.eval_classes)))
+        else:
+            if len(self._eval_categories) != len(self.eval_classes):
+                raise ValueError(
+                    "eval_categories must align one-to-one with eval_classes: "
+                    f"{len(self._eval_categories)} != {len(self.eval_classes)}"
+                )
+            self.eval_category_ids = [
+                category_id
+                for category_id, category in enumerate(self._eval_categories)
+                if bool(category.get("isthing", 1))
+            ]
+        if not self.eval_category_ids:
+            raise ValueError("instance mAP requires at least one evaluated thing category")
+
+        self.model.set_vocab(self.classes, device=self.device)
+        self._vocab_set = True
+
+    def on_train_epoch_start(self):
+        """Update the train sampler at the start of each epoch."""
+        # Propagate the epoch to the train sampler so the data is reshuffled
+        # every epoch. ``train.py`` sets ``use_distributed_sampler=False``
+        # (the data modules build their own DistributedSampler /
+        # HomogeneousBatchSampler), so PyTorch Lightning does NOT call
+        # ``sampler.set_epoch`` for us. Without this the sampler keeps
+        # re-using its epoch-0 seed and every epoch sees the identical batch
+        # ordering / dataset-choice sequence.
+        datamodule = getattr(self.trainer, "datamodule", None)
+        if datamodule is not None and hasattr(datamodule, "set_train_epoch"):
+            datamodule.set_train_epoch(self.current_epoch)
+
+    def zero_loss(self):
+        """Return a zero loss connected to model params so DDP gradient sync works."""
+        return sum(p.reshape(-1)[0] * 0.0 for p in self.model.parameters() if p.requires_grad)
+
+    def training_step(self, batch, batch_idx):
+        """Training step."""
+        if not self._vocab_set:
+            logger.warning("Vocabulary not set. Call set_classes() before training.")
+            return self.zero_loss()
+
+        imgs = torch.stack([b["img"] for b in batch], dim=1)
+        true_shape = torch.stack([b["true_shape"] for b in batch], dim=1)
+
+        precision = str(get_cfg_val(self.train_cfg, "precision", "fp32")).lower()
+        if precision == "bf16":
+            dtype = torch.bfloat16
+        elif precision == "fp16":
+            dtype = torch.float16
+        else:
+            dtype = torch.float32
+
+        # Collators doing per-batch text augmentation attach a ``vocab`` to the
+        # first view dict, replacing the model's text input and aligning the
+        # criterion's class indices with the rewritten ``pan_cls_id`` pixels.
+        vocab = batch[0].get("vocab", self.classes) if isinstance(batch[0], dict) else self.classes
+
+        with torch.amp.autocast("cuda", dtype=dtype):
+            panout, geo_out = self.model(imgs, true_shape, vocab)
+
+        gt_depth = None
+        if "depthmap" in batch[0]:
+            gt_depth = torch.stack([b["depthmap"] for b in batch], dim=1)  # [B, S, H, W]
+
+        with torch.amp.autocast("cuda", dtype=torch.float32):
+            loss, loss_details = self.criterion(
+                batch, panout, vocab,
+                geometry_output=geo_out,
+                gt_depth=gt_depth,
+            )
+
+        if not torch.isfinite(loss):
+            logger.warning(
+                "Non-finite loss at step %d (rank %d) — using zero loss for DDP safety.",
+                batch_idx, self.global_rank,
+            )
+            loss = self.zero_loss()
+            loss_details = {k: torch.zeros(1, device=imgs.device) for k in loss_details}
+
+        total_steps = self.trainer.num_training_batches
+        step = batch_idx + 1
+        should_log = step % self._log_interval == 0 or step == total_steps
+        if should_log:
+            for k, v in loss_details.items():
+                if isinstance(v, torch.Tensor):
+                    v = v.item()
+                self.log(f"train/{k}", v, prog_bar=False, sync_dist=True)
+
+        return loss
+
+    def extract_scene_id(self, batch, bi: int):
+        """Extract scene_id from a batch sample's label."""
+        label = batch[0].get("label")
+        if label is None:
+            return None
+        if isinstance(label, (list, tuple)):
+            label = label[bi]
+        parts = label.rsplit("_", 1)
+        return parts[0] if len(parts) >= 2 else label
+
+    def forward_panoptic(self, batch, *, for_inference=False):
+        """Run the model and panoptic post-processing on one evaluation batch.
+
+        Returns:
+            tuple of (pred_results, geometry_output, batch_size, num_views).
+        """
+        imgs = torch.stack([b["img"] for b in batch], dim=1)
+        true_shape = torch.stack([b["true_shape"] for b in batch], dim=1)
+
+        # Evaluation uses the same native ScanNet++ taxonomy as training.
+        vocab = self.eval_classes
+
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            panout, geo_out = self.model(imgs, true_shape, vocab)
+
+        if for_inference:
+            cls_threshold = self.inference_cls_threshold
+            mask_threshold = self.inference_mask_threshold
+            overlap_threshold = self.inference_overlap_threshold
+        else:
+            cls_threshold = self.cls_threshold
+            mask_threshold = self.mask_threshold
+            overlap_threshold = self.overlap_threshold
+
+        H, W = true_shape[0, 0].tolist()
+        pred_results = panoptic_inference(
+            mask_cls=panout["pred_logits"],
+            mask_pred=panout["pred_masks"],
+            target_hw=(int(H), int(W)),
+            label_mode=self.model.panoptic_decoder.label_mode,
+            cls_threshold=cls_threshold,
+            mask_threshold=mask_threshold,
+            overlap_threshold=overlap_threshold,
+            objectness_logits=panout.get("pred_objectness"),
+        )
+        return pred_results, geo_out, imgs.shape[0], imgs.shape[1]
+
+    def accumulate_map(self, batch, pred_results, batch_size, num_views):
+        """Convert one batch into compact per-sample AP matching tables."""
+        num_classes = len(self.eval_classes)
+        for bi in range(batch_size):
+            pred_pan = pred_results[bi]["pan"].cpu().numpy()
+            pred_segments = pred_results[bi]["segments_info"]
+            gt_instance_ids = np.stack([
+                batch[v]["pan_inst_id"][bi].cpu().numpy()
+                for v in range(num_views)
+            ])
+            gt_class_ids = np.stack([
+                batch[v]["pan_cls_id"][bi].cpu().numpy()
+                for v in range(num_views)
+            ])
+            self.all_map_samples.append(prepare_instance_map_sample(
+                pred_pan,
+                pred_segments,
+                gt_instance_ids,
+                gt_class_ids,
+                num_categories=num_classes,
+                evaluated_category_ids=self.eval_category_ids,
+            ))
+
+    def aggregate_map(self, prefix: str):
+        """Aggregate all ranks into dataset-level mAP, mAP50, and mAP25.
+
+        Per-sample intersection tables are gathered from every DDP rank before
+        AP is computed, so confidence ranking and false-negative accounting
+        cover the complete evaluation set.
+
+        Args:
+            prefix: metric namespace, e.g. ``val`` or ``test``.
+
+        Returns:
+            The three-metric dictionary, or ``None`` if no samples were seen.
+        """
+        if self.eval_category_ids is None:
+            return None
+
+        if dist.is_initialized():
+            gathered = [None] * dist.get_world_size()
+            dist.all_gather_object(gathered, self.all_map_samples)
+            all_samples = []
+            for rank_samples in gathered:
+                all_samples.extend(rank_samples)
+        else:
+            all_samples = list(self.all_map_samples)
+
+        if not all_samples:
+            self.all_map_samples.clear()
+            return None
+
+        metrics = evaluate_instance_map_segvggt(
+            all_samples, self.eval_category_ids,
+        )
+        self.log(f"{prefix}/mAP", metrics["mAP"], prog_bar=True)
+        self.log(f"{prefix}/mAP50", metrics["mAP50"])
+        self.log(f"{prefix}/mAP25", metrics["mAP25"])
+
+        self.all_map_samples.clear()
+        return metrics
+
+    def validation_step(self, batch, batch_idx):
+        """Validation step with instance mAP tracking."""
+        del batch_idx
+        if not self._vocab_set:
+            return None
+
+        pred_results, _, batch_size, num_views = self.forward_panoptic(batch)
+        self.accumulate_map(batch, pred_results, batch_size, num_views)
+        return None
+
+    def on_validation_epoch_end(self):
+        """Aggregate validation mAP, mAP50, and mAP25."""
+        self.aggregate_map("val")
+
+    def test_step(self, batch, batch_idx):
+        """Evaluation step. Identical scoring to validation."""
+        del batch_idx
+        if not self._vocab_set:
+            return None
+
+        pred_results, _, batch_size, num_views = self.forward_panoptic(batch)
+        self.accumulate_map(batch, pred_results, batch_size, num_views)
+        return None
+
+    def on_test_epoch_end(self):
+        """Aggregate the evaluation metrics and persist them to results_dir."""
+        metrics = self.aggregate_map("test")
+        if metrics is None or self.global_rank != 0:
+            return
+
+        results_dir = self.experiment_spec["results_dir"]
+        if not results_dir:
+            return
+        os.makedirs(results_dir, exist_ok=True)
+        results_path = os.path.join(results_dir, "instance_map.json")
+        with open(results_path, "w", encoding="utf-8") as handle:
+            json.dump({k: float(v) for k, v in metrics.items()}, handle, indent=2)
+        logger.info("Wrote evaluation metrics to %s", results_path)
+
+    def predict_step(self, batch, batch_idx, dataloader_idx=0):
+        """Inference step. Dumps one panoptic map per sample to results_dir.
+
+        Each sample is written as a compressed ``.npz`` holding the multi-view
+        panoptic ID map, the per-segment ``id``/``category_id``/``score``
+        table, and the class names those category IDs index into. Metric depth
+        and metric world points are included when the metric-scale head is
+        enabled.
+        """
+        del dataloader_idx
+        if not self._vocab_set:
+            return None
+
+        pred_results, geo_out, batch_size, _ = self.forward_panoptic(
+            batch, for_inference=True,
+        )
+
+        output_dir = self.inference_output_dir()
+        os.makedirs(output_dir, exist_ok=True)
+
+        for bi in range(batch_size):
+            payload = {
+                "pan": pred_results[bi]["pan"].cpu().numpy(),
+                "segments_info": np.array(
+                    json.dumps(pred_results[bi]["segments_info"]), dtype=object,
+                ),
+                "classes": np.array(self.eval_classes, dtype=object),
+            }
+            for key in ("metric_depth", "metric_points"):
+                if key in geo_out:
+                    payload[key] = geo_out[key][bi].float().cpu().numpy()
+
+            label = self.extract_scene_id(batch, bi) or "sample"
+            index = batch_idx * batch_size + bi
+            out_path = os.path.join(
+                output_dir, f"{label}_{self.global_rank:02d}_{index:06d}.npz",
+            )
+            np.savez_compressed(out_path, **payload)
+
+        return None
+
+    def inference_output_dir(self):
+        """Resolve where predict_step writes, honouring inference.output_dir."""
+        inference_cfg = get_cfg_val(self.cfg, "inference", None)
+        output_dir = get_cfg_val(inference_cfg, "output_dir", None)
+        if output_dir:
+            return str(output_dir)
+        return os.path.join(str(self.experiment_spec["results_dir"]), "predictions")
+
+    def configure_optimizers(self):
+        """Configure optimizer with per-component learning rates and a
+        linear-warmup -> cosine-decay LR schedule.
+
+        The schedule is stepped **per optimizer step** and honours the
+        ``train`` config's ``warmup_epochs``, ``num_epochs`` and ``min_lr``.
+        It is implemented as a multiplicative :class:`LambdaLR`, so every
+        parameter group is annealed by the same factor.
+
+        Previously this method returned only the optimizer, so
+        ``warmup_epochs`` / ``min_lr`` were silently ignored and the LR
+        stayed constant at ``lr`` for the entire run.
+        """
+        lr = get_cfg_val(self.train_cfg, "lr", 1e-4)
+        min_lr = get_cfg_val(self.train_cfg, "min_lr", 1e-6)
+        weight_decay = get_cfg_val(self.train_cfg, "weight_decay", 0.05)
+
+        param_groups = adamw_parameter_groups(
+            self.model.panoptic_decoder,
+            lr=lr,
+            weight_decay=weight_decay,
+            component_name="panoptic_decoder",
+        )
+
+        if self.model.metric_depth_head is not None:
+            head_groups = adamw_parameter_groups(
+                self.model.metric_depth_head,
+                lr=lr,
+                weight_decay=weight_decay,
+                component_name="metric_depth_head",
+            )
+            param_groups.extend(head_groups)
+
+        optimizer = torch.optim.AdamW(
+            param_groups,
+            betas=(0.9, 0.95),
+            weight_decay=0.0,
+        )
+
+        # LR schedule: linear warmup -> cosine decay (per optim step)
+        # ``estimated_stepping_batches`` is the total optimizer-step budget
+        # over the whole run; it already accounts for max_epochs,
+        # grad accumulation, devices and nodes. Guard with a fallback so a
+        # missing/odd trainer state degrades to the old constant-LR behaviour
+        # instead of crashing.
+        try:
+            total_steps = int(self.trainer.estimated_stepping_batches)
+        except Exception:
+            total_steps = 0
+        if total_steps <= 1:
+            return optimizer
+
+        num_epochs = int(get_cfg_val(self.train_cfg, "num_epochs", 10) or 0)
+        warmup_epochs = float(get_cfg_val(self.train_cfg, "warmup_epochs", 2.0) or 0)
+
+        # Convert warmup epochs to a fraction of the DDP-aware optimizer-step
+        # budget. ``estimated_stepping_batches`` already accounts for devices,
+        # accumulation, the epoch limit, and the distributed sampler.
+        if num_epochs > 0 and warmup_epochs > 0:
+            warmup_frac = min(max(warmup_epochs / num_epochs, 0.0), 0.5)
+            warmup_steps = int(total_steps * warmup_frac)
+        else:
+            warmup_steps = 0
+        warmup_steps = max(0, min(warmup_steps, total_steps - 1))
+
+        min_ratio = (float(min_lr) / float(lr)) if lr > 0 else 0.0
+        min_ratio = max(0.0, min(min_ratio, 1.0))
+
+        def lr_lambda(current_step: int) -> float:
+            if warmup_steps > 0 and current_step < warmup_steps:
+                return float(current_step) / float(max(1, warmup_steps))
+            progress = float(current_step - warmup_steps) / float(max(1, total_steps - warmup_steps))
+            progress = min(1.0, max(0.0, progress))
+            cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
+            return min_ratio + (1.0 - min_ratio) * cosine
+
+        scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+
+        logger.info(
+            "LR schedule: linear warmup %d steps -> cosine decay over %d total "
+            "steps (lr %.2e -> %.2e, %d param groups)",
+            warmup_steps, total_steps, lr, min_lr, len(param_groups),
+        )
+
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {
+                "scheduler": scheduler,
+                "interval": "step",
+                "frequency": 1,
+            },
+        }

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/text_encoder.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/panoptic/text_encoder.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frozen SigLIP text encoder for open-vocabulary panoptic segmentation."""
+
+import os
+
+import torch
+from torch import nn
+from transformers import AutoTokenizer, SiglipTextModel
+
+
+MODEL_ID = "google/siglip-base-patch16-224"
+EMBED_DIM = 768
+PROMPT_TEMPLATE = "This is a photo of {}."
+
+
+class TextEncoder(nn.Module):
+    """Produce L2-normalized SigLIP embeddings for class names.
+
+    Args:
+        fixed_vocab: When ``True``, ``set_vocab`` must be called once
+            up-front to pre-cache embeddings; subsequent ``forward(classes)``
+            calls become dictionary look-ups (no SigLIP forward pass per
+            training step). When ``False``, ``forward(classes)`` re-encodes
+            the text every call -- useful for variable-vocabulary inference.
+    """
+
+    def __init__(self, fixed_vocab: bool = False):
+        super().__init__()
+        self.embed_dim = EMBED_DIM
+        self.fixed_vocab = fixed_vocab
+        if self.fixed_vocab:
+            self.class_embeddings = {}
+        else:
+            self.model, self.tokenizer = self.get_model()
+
+    def get_model(self):
+        """Load the frozen SigLIP text model and tokenizer."""
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+        model = SiglipTextModel.from_pretrained(MODEL_ID)
+        model.eval()
+
+        for param in model.parameters():
+            param.requires_grad = False
+
+        return model, tokenizer
+
+    def encode_batch(self, model, tokenizer, texts, bs=256):
+        """Encode a flat list of text strings into pooled embeddings."""
+        embs = []
+        total = len(texts)
+        with torch.no_grad():
+            for i in range(0, total, bs):
+                inputs = tokenizer(
+                    texts[i:i + bs], return_tensors='pt',
+                    padding='max_length',
+                )
+                inputs = {k: v.to(model.device) for k, v in inputs.items()}
+                lang_emb = model(**inputs).pooler_output.detach()
+                embs.append(lang_emb)
+        return torch.cat(embs)
+
+    def embed_classes(self, model, tokenizer, classes, bs=256):
+        """Encode class names with the SigLIP prompt template."""
+        texts = [PROMPT_TEMPLATE.format(c) for c in classes]
+        return self.encode_batch(model, tokenizer, texts, bs=bs)
+
+    def set_vocab(self, classes: list[str], device=None):
+        """Pre-encode and cache embeddings keyed by exact text."""
+        model, tokenizer = self.get_model()
+
+        # Prefer CUDA even when the pre-Trainer caller reports CPU, since this
+        # is a one-shot startup encode. Respect an explicit CUDA device for
+        # inference; otherwise select torchrun's local rank.
+        if torch.cuda.is_available():
+            requested = torch.device(device) if device is not None else None
+            if requested is not None and requested.type == "cuda":
+                target_device = requested
+            else:
+                local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+                target_device = torch.device("cuda", local_rank)
+        elif device is not None:
+            target_device = torch.device(device)
+        else:
+            target_device = torch.device("cpu")
+        model.to(target_device)
+
+        lang_emb = self.embed_classes(model, tokenizer, classes)
+        self.class_embeddings = {c: emb for c, emb in zip(classes, lang_emb)}
+
+        del model, tokenizer
+        torch.cuda.empty_cache()
+
+    def forward(self, classes: list[str]):
+        """Return the language embeddings for a list of class names."""
+        if self.fixed_vocab:
+            missing = [
+                class_name
+                for class_name in classes
+                if class_name not in self.class_embeddings
+            ]
+            if missing:
+                raise ValueError(
+                    "Missing classes in fixed vocabulary: "
+                    f"{', '.join(missing)}. Call set_vocab() before forward."
+                )
+            lang_emb = torch.stack([self.class_embeddings[c] for c in classes])
+        else:
+            lang_emb = self.embed_classes(self.model, self.tokenizer, classes)
+
+        out = lang_emb / lang_emb.norm(dim=-1, keepdim=True)
+
+        return out

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning-segmentation variant of the NVPanoptix3Dv2 model."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/pl_model.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/pl_model.py
@@ -1,0 +1,668 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lightning module for NVPanoptix3Dv2-Reasoning projector training."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from typing import Dict, List, Sequence
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+import torch.nn.functional as F
+from PIL import Image
+from pytorch_lightning.callbacks import Callback, ModelCheckpoint
+
+from nvidia_tao_pytorch.core.callbacks.model_checkpoint import TAOExceptionCheckpoint
+from nvidia_tao_pytorch.core.callbacks.loggers import TAOStatusLogger
+from nvidia_tao_pytorch.core.lightning.tao_lightning_module import TAOLightningModule
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.metric_scale_head import (
+    MetricScaleHead,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning.qwen_builder import (
+    build_qwen,
+    cfg_get as _cfg,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning.reasoning_model import (
+    NVPanoptix3Dv2Reasoning,
+    SegToSAMPromptProjector,
+    set_requires_grad,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.reasoning.masks import (
+    gather_view_masks,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.reasoning.score import (
+    CanonicalPointCloudMetrics,
+    score_batch_on_canonical_points,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.reasoning.losses import (
+    NVPanoptix3Dv2ReasoningLoss,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_sam3_image_model_from_config(model_cfg):
+    """Build the frozen SAM3 image model through the shared TAO backbone helper."""
+    from nvidia_tao_pytorch.cv.backbone_v2.sam3 import get_sam3_model
+
+    reasoning_cfg = _cfg(model_cfg, "reasoning", {})
+    sam_cfg = _cfg(reasoning_cfg, "sam3", {})
+    if torch.cuda.is_available():
+        local_rank = int(os.environ.get("LOCAL_RANK", os.environ.get("SLURM_LOCALID", "0")) or 0)
+        torch.cuda.set_device(local_rank)
+    checkpoint = _cfg(sam_cfg, "checkpoint", None)
+    load_from_hf = bool(_cfg(sam_cfg, "load_from_hf", True)) and not checkpoint
+    sam, _ = get_sam3_model(
+        chk_base_path=str(checkpoint) if checkpoint else None,
+        wrap=False,
+        load_from_HF=load_from_hf,
+    )
+    set_requires_grad(sam, False)
+    sam.eval()
+    return sam
+
+
+def filter_unsupported_vggt_weights(
+    state: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Drop the upstream tracking head, which is not vendored by this model."""
+    filtered = {
+        key: value for key, value in state.items()
+        if not key.startswith("track_head.")
+    }
+    dropped = len(state) - len(filtered)
+    if dropped:
+        logger.info("Dropped %d unsupported VGGT tracking tensors", dropped)
+    return filtered
+
+
+def build_vggt_geometry_model_from_config(model_cfg):
+    """Build the frozen VGGT backbone shared with the panoptic variant."""
+    backbone_cfg = _cfg(model_cfg, "backbone", {})
+
+    from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt import VGGT
+
+    vggt = VGGT(
+        img_size=int(_cfg(model_cfg, "img_size", 518)),
+        patch_size=int(_cfg(model_cfg, "patch_size", 14)),
+        embed_dim=int(_cfg(model_cfg, "embed_dim", 1024)),
+    )
+    checkpoint = _cfg(backbone_cfg, "pretrained_backbone_path", None)
+    if checkpoint and os.path.exists(str(checkpoint)):
+        state = torch.load(str(checkpoint), map_location="cpu", weights_only=False)
+        if isinstance(state, dict) and "state_dict" in state:
+            state = state["state_dict"]
+        if isinstance(state, dict) and "model" in state and isinstance(state["model"], dict):
+            state = state["model"]
+        state = filter_unsupported_vggt_weights(state)
+        strict = bool(_cfg(backbone_cfg, "strict_load", True))
+        incompatible = vggt.load_state_dict(state, strict=strict)
+        if not strict and (incompatible.missing_keys or incompatible.unexpected_keys):
+            logger.warning(
+                "VGGT checkpoint loaded non-strictly: %d missing keys, %d unexpected keys",
+                len(incompatible.missing_keys),
+                len(incompatible.unexpected_keys),
+            )
+    elif bool(_cfg(backbone_cfg, "load_from_hf", False)):
+        vggt = VGGT.from_pretrained("facebook/VGGT-1B")
+    else:
+        raise FileNotFoundError(
+            f"VGGT checkpoint not found at {checkpoint!r}; set "
+            "model.backbone.pretrained_backbone_path or enable "
+            "model.backbone.load_from_hf."
+        )
+    set_requires_grad(vggt, False)
+    vggt.eval()
+    return vggt
+
+
+def checkpoint_state_dict(path: str) -> Dict[str, torch.Tensor]:
+    """Load and unwrap a model state dictionary from ``path``."""
+    ckpt = torch.load(str(path), map_location="cpu", weights_only=False)
+    if isinstance(ckpt, dict) and "state_dict" in ckpt:
+        return ckpt["state_dict"]
+    if isinstance(ckpt, dict) and "model" in ckpt and isinstance(ckpt["model"], dict):
+        return ckpt["model"]
+    return ckpt
+
+
+def build_metric_depth_head_from_config(model_cfg):
+    """Build the shared metric scale head in its scale+shift configuration."""
+    backbone_cfg = _cfg(model_cfg, "backbone", {})
+    head_cfg = _cfg(backbone_cfg, "metric_depth_head", {})
+    if not bool(_cfg(head_cfg, "enable", True)):
+        return None
+    hidden_dims = _cfg(head_cfg, "hidden_dims", None)
+    if hidden_dims is None:
+        hidden = int(_cfg(head_cfg, "hidden_dim", 256))
+        hidden_dims = [hidden, max(hidden // 4, 16)]
+    metric_head = MetricScaleHead(
+        scene_token_dim=int(_cfg(head_cfg, "feat_dim", 2048)),
+        hidden_dims=tuple(hidden_dims),
+        metric_context_views=int(_cfg(head_cfg, "metric_context_views", 5)),
+        predict_shift=bool(_cfg(head_cfg, "predict_shift", True)),
+    )
+    return metric_head
+
+
+def build_reasoning_model_from_config(cfg) -> NVPanoptix3Dv2Reasoning:
+    """Assemble Qwen + frozen SAM3 + frozen VGGT + the trainable projector."""
+    model_cfg = _cfg(cfg, "model")
+    reasoning_cfg = _cfg(model_cfg, "reasoning", {})
+    qwen = build_qwen(_cfg(reasoning_cfg, "qwen", {}))
+    sam = build_sam3_image_model_from_config(model_cfg)
+    vggt = build_vggt_geometry_model_from_config(model_cfg)
+    metric_head = build_metric_depth_head_from_config(model_cfg)
+    sam_cfg = _cfg(reasoning_cfg, "sam3", {})
+    bridge_cfg = _cfg(reasoning_cfg, "sam_bridge", {})
+    projector = SegToSAMPromptProjector(
+        d_llm=qwen.hidden_size,
+        d_sam=int(_cfg(bridge_cfg, "sam_prompt_dim", 256)),
+        hidden=int(_cfg(bridge_cfg, "hidden_dim", 4096)),
+        dropout=float(_cfg(bridge_cfg, "dropout", 0.0)),
+    )
+    conf_threshold = _cfg(reasoning_cfg, "point_conf_threshold", None)
+    return NVPanoptix3Dv2Reasoning(
+        qwen=qwen,
+        sam3_image_model=sam,
+        projector=projector,
+        vggt_geometry_model=vggt,
+        metric_depth_head=metric_head,
+        sam_resolution=int(_cfg(sam_cfg, "resolution", 1008)),
+        point_mask_threshold=float(_cfg(reasoning_cfg, "point_mask_threshold", 0.5)),
+        point_conf_threshold=None if conf_threshold is None else float(conf_threshold),
+        freeze_sam=True,
+        freeze_vggt=True,
+    )
+
+
+def build_sam_criterion(cfg) -> NVPanoptix3Dv2ReasoningLoss:
+    """Build the reasoning loss from ``train.reasoning`` and ``train.metric_depth``."""
+    train_cfg = _cfg(cfg, "train")
+    loss_cfg = _cfg(train_cfg, "reasoning", {})
+    metric_cfg = _cfg(train_cfg, "metric_depth", {})
+    return NVPanoptix3Dv2ReasoningLoss(
+        text_weight=float(_cfg(loss_cfg, "text_weight", 1.0)),
+        mask_weight=float(_cfg(loss_cfg, "mask_weight", 20.0)),
+        dice_weight=float(_cfg(loss_cfg, "dice_weight", 1.0)),
+        score_weight=float(_cfg(loss_cfg, "score_weight", 1.0)),
+        metric_weight=float(_cfg(metric_cfg, "weight", 5.0)),
+        metric_silog_weight=float(_cfg(metric_cfg, "silog_weight", 1.0)),
+        metric_absrel_weight=float(_cfg(metric_cfg, "absrel_weight", 0.1)),
+        metric_silog_lambda=float(_cfg(metric_cfg, "silog_lambda", 0.85)),
+        metric_min_depth=float(_cfg(metric_cfg, "min_depth", 0.1)),
+        metric_max_depth=float(_cfg(metric_cfg, "max_depth", 20.0)),
+    )
+
+
+class NVPanoptix3Dv2ReasoningPlModule(TAOLightningModule):
+    """Reasoning-segmentation variant: Qwen ``[SEG]`` -> frozen SAM3 -> VGGT lift.
+
+    Inherits from TAOLightningModule for the shared TAO checkpoint/status
+    plumbing; the checkpoint policy itself is overridden in
+    :meth:`configure_callbacks` because only trainable LoRA/projector rows
+    are persisted.
+    """
+
+    def __init__(self, experiment_config):
+        """Build the reasoning model, its criterion, and the eval metrics."""
+        super().__init__(experiment_config)
+        self.cfg = experiment_config
+        self.train_cfg = _cfg(experiment_config, "train")
+        self.model = build_reasoning_model_from_config(experiment_config)
+        self.criterion = build_sam_criterion(experiment_config)
+        self.checkpoint_filename = "nvpanoptix3d_v2_reasoning_model"
+        # Best-checkpoint selection ranks on canonical point-cloud mIoU.
+        self.monitor_metric = "val/mIoU"
+        self.monitor_mode = "max"
+        self.strict_loading = False
+        self._log_interval = int(_cfg(self.train_cfg, "log_interval", 50))
+
+        resume_ckpt = _cfg(self.train_cfg, "resume_training_checkpoint_path", None)
+        has_resume = bool(resume_ckpt and os.path.isfile(str(resume_ckpt)))
+        if not has_resume:
+            results_dir = _cfg(experiment_config, "results_dir", None)
+            if results_dir:
+                latest = os.path.join(
+                    str(results_dir), self.checkpoint_filename + "_latest.pth",
+                )
+                has_resume = os.path.exists(latest)
+
+        pretrained = _cfg(self.train_cfg, "pretrained_model_path", None)
+        if pretrained and os.path.isfile(str(pretrained)) and not has_resume:
+            self.load_pretrained_weights(str(pretrained))
+        elif pretrained and has_resume:
+            logger.info(
+                "Skipping pretrained_model_path (resume checkpoint found; it takes priority)"
+            )
+        elif pretrained:
+            raise FileNotFoundError(
+                f"Reasoning pretrained_model_path does not exist: {pretrained}"
+            )
+
+        # Canonical point-cloud validation metrics.
+        eval_cfg = _cfg(experiment_config, "evaluate", {})
+        self._eval_mask_thresh = float(_cfg(eval_cfg, "mask_threshold", 0.5))
+        self._val_metrics: CanonicalPointCloudMetrics | None = None
+
+        total = sum(p.numel() for p in self.model.parameters())
+        trainable = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
+        logger.info("NVPanoptix3Dv2-Reasoning: %.1fM total, %.1fM trainable", total / 1e6, trainable / 1e6)
+
+    def load_pretrained_weights(self, checkpoint_path: str) -> None:
+        """Warm-start compatible reasoning weights without optimizer state."""
+        raw_state = checkpoint_state_dict(checkpoint_path)
+        if not isinstance(raw_state, dict):
+            raise TypeError(
+                f"Expected a state dict in {checkpoint_path}, got "
+                f"{type(raw_state).__name__}."
+            )
+
+        destination = self.state_dict()
+        compatible = {}
+        skipped_shape = []
+        for source_key, value in raw_state.items():
+            candidates = [source_key]
+            if not source_key.startswith("model."):
+                candidates.append("model." + source_key)
+            target_key = next((key for key in candidates if key in destination), None)
+            if target_key is None:
+                continue
+            if not hasattr(value, "shape") or value.shape != destination[target_key].shape:
+                skipped_shape.append(target_key)
+                continue
+            compatible[target_key] = value
+
+        if not compatible:
+            raise ValueError(
+                f"No compatible reasoning weights found in {checkpoint_path}."
+            )
+        self.load_state_dict(compatible, strict=False)
+        logger.info(
+            "Warm-started %d reasoning tensors from %s (%d shape mismatches skipped)",
+            len(compatible), checkpoint_path, len(skipped_shape),
+        )
+
+    @staticmethod
+    def tensors_to_pil(imgs: torch.Tensor) -> List[List[Image.Image]]:
+        """``[B,S,3,H,W]`` in [0,1] -> list of PIL views for Qwen."""
+        B, S = imgs.shape[:2]
+        out: List[List[Image.Image]] = []
+        for b in range(B):
+            views = []
+            for s in range(S):
+                arr = (
+                    imgs[b, s].permute(1, 2, 0).clamp(0, 1).float().cpu().numpy() * 255.0
+                )
+                views.append(Image.fromarray(arr.astype(np.uint8)))
+            out.append(views)
+        return out
+
+    def forward_batch(self, batch):
+        """Run one reasoning batch and return its loss, logs, and outputs."""
+        imgs = torch.stack([v["img"] for v in batch], dim=1).to(self.device)          # [B,S,3,H,W]
+        pan_inst = torch.stack([v["pan_inst_id"] for v in batch], dim=1).to(self.device)  # [B,S,H,W]
+        gt_depth = None
+        if all("depthmap" in v for v in batch):
+            gt_depth = torch.stack([v["depthmap"] for v in batch], dim=1).to(self.device)
+        instruction = batch[0]["instruction"]
+        answer = batch[0]["answer"]
+        target_inst = batch[0]["target_inst_id"].to(self.device)
+        seg_view_indices = batch[0].get("seg_view_indices") or [[0]] * len(instruction)
+
+        qwen_inputs = self.model.qwen.build_inputs(
+            self.tensors_to_pil(imgs),
+            instruction,
+            answer,
+            device=self.device,
+        )
+        out = self.model(imgs, qwen_inputs, seg_view_indices=seg_view_indices)
+        gt_sel = gather_view_masks(                                                    # [N,H,W]
+            pan_inst, target_inst, out["seg_sample_idx"], out["seg_view_idx"]
+        )
+        mask_valid = target_inst[out["seg_sample_idx"]] > 0                            # [N]
+        loss, logs = self.criterion(out, gt_sel, mask_valid, gt_depth=gt_depth)
+        clouds = out.get("segmented_point_clouds")
+        if clouds is not None:
+            counts = [int(points.shape[0]) for points in clouds]
+            logs["segmented_points_mean"] = float(sum(counts) / max(len(counts), 1))
+        return loss, logs, out
+
+    def training_step(self, batch, batch_idx):
+        """Training step."""
+        loss, logs, _ = self.forward_batch(batch)
+        for k, v in logs.items():
+            self.log(f"train/{k}", v, batch_size=1, prog_bar=False, sync_dist=True)
+        if self.trainer.is_global_zero and batch_idx % self._log_interval == 0:
+            logger.info(
+                "step %d | total %.4f text %.4f mask %.4f dice %.4f score %.4f n_valid=%d",
+                batch_idx,
+                logs["loss_total"],
+                logs["loss_text"],
+                logs["loss_mask"],
+                logs["loss_dice"],
+                logs["loss_score"],
+                int(logs["n_mask_valid"]),
+            )
+        return loss
+
+    def on_validation_epoch_start(self):
+        """Reset canonical point-cloud metrics for this validation epoch."""
+        self._val_metrics = CanonicalPointCloudMetrics()
+
+    def validation_step(self, batch, batch_idx):
+        """Validation step with canonical point-cloud metric accumulation."""
+        del batch_idx
+        loss, logs, out = self.forward_batch(batch)
+        for k, v in logs.items():
+            self.log(f"val/{k}", v, batch_size=1, sync_dist=True)
+        self.accumulate_val_metrics(batch, out)
+        return loss
+
+    def accumulate_val_metrics(self, batch, out):
+        """Score this batch on canonical, metric-depth-defined points."""
+        if self._val_metrics is None:
+            return
+        pan_inst = torch.stack(
+            [view["pan_inst_id"] for view in batch], dim=1,
+        ).to(self.device)
+        depth = torch.stack(
+            [view["depthmap"] for view in batch], dim=1,
+        ).to(self.device)
+        target_inst = batch[0]["target_inst_id"].to(self.device)
+        canonical_valid = torch.isfinite(depth) & (depth > 0)
+        score_batch_on_canonical_points(
+            self._val_metrics,
+            out,
+            pan_inst,
+            target_inst,
+            canonical_valid,
+            self._eval_mask_thresh,
+        )
+
+    def reduce_and_compute_metrics(self):
+        """All-reduce additive state and compute metrics over the full split."""
+        if self._val_metrics is None:
+            return None
+        stats = torch.tensor(
+            self._val_metrics.raw_state(), dtype=torch.float64, device=self.device
+        )
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.all_reduce(stats, op=torch.distributed.ReduceOp.SUM)
+        self._val_metrics.load_raw_state(stats.tolist())
+        return self._val_metrics.compute()
+
+    def on_validation_epoch_end(self):
+        """Log mIoU, mAP50, and mAP25 over the full validation split."""
+        if self._val_metrics is None:
+            return
+        res = self.reduce_and_compute_metrics()
+        if not res:
+            return
+
+        keys = ["mIoU", "mAP50", "mAP25"]
+        for k in keys:
+            self.log(
+                f"val/{k}",
+                float(res[k]),
+                prog_bar=(k == "mIoU"),
+                sync_dist=False,
+            )
+        if self.trainer.is_global_zero:
+            summary = "  ".join(f"{key}={res[key]:.4f}" for key in keys)
+            logger.info(
+                "[NVPanoptix3Dv2-Reasoning][Ep %d][val] %s",
+                self.current_epoch,
+                summary,
+            )
+
+    def on_validation_start(self):
+        """Skip the base dataloader size check when no val manifest is set."""
+        if self.trainer.datamodule.val_dataloader() is None:
+            return
+        super().on_validation_start()
+
+    def on_test_start(self):
+        """Skip the base dataloader size check when no val manifest is set."""
+        if self.trainer.datamodule.test_dataloader() is None:
+            return
+        super().on_test_start()
+
+    def on_predict_start(self):
+        """Skip the base dataloader size check when no val manifest is set."""
+        if self.trainer.datamodule.predict_dataloader() is None:
+            return
+        super().on_predict_start()
+
+    def on_test_epoch_start(self):
+        """Reset canonical point-cloud metrics for the evaluate subtask."""
+        self.on_validation_epoch_start()
+
+    def test_step(self, batch, batch_idx):
+        """Evaluation step. Identical scoring to validation."""
+        del batch_idx
+        _, _, out = self.forward_batch(batch)
+        self.accumulate_val_metrics(batch, out)
+
+    def on_test_epoch_end(self):
+        """Persist mIoU, mAP50, and mAP25 to results_dir."""
+        res = self.reduce_and_compute_metrics()
+        if not res:
+            return
+        keys = ["mIoU", "mAP50", "mAP25"]
+        for k in keys:
+            self.log(f"test/{k}", float(res[k]), sync_dist=False)
+        if self.global_rank != 0:
+            return
+        results_dir = self.experiment_spec["results_dir"]
+        if not results_dir:
+            return
+        os.makedirs(results_dir, exist_ok=True)
+        results_path = os.path.join(results_dir, "reasoning_point_cloud_metrics.json")
+        with open(results_path, "w", encoding="utf-8") as handle:
+            json.dump({key: float(res[key]) for key in keys}, handle, indent=2)
+        logger.info("Wrote evaluation metrics to %s", results_path)
+
+    def predict_step(self, batch, batch_idx, dataloader_idx=0):
+        """Inference step. Dumps one prediction per ``[SEG]`` binding.
+
+        Each binding is written as a compressed ``.npz`` holding the binarized
+        2D mask, its sample/view ids, and the fused segmented point cloud for
+        that sample. When ``inference.save_full_point_cloud`` is enabled, one
+        additional ``cloud_*.npz`` per sample stores dense points, aligned RGB,
+        and the fused multi-view segmentation mask for visualization.
+        """
+        del dataloader_idx
+        _, _, out = self.forward_batch(batch)
+
+        inference_cfg = _cfg(self.cfg, "inference", None)
+        output_dir = _cfg(inference_cfg, "output_dir", None)
+        output_dir = str(output_dir) if output_dir else os.path.join(
+            str(self.experiment_spec["results_dir"]), "predictions",
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        mask_threshold = float(_cfg(
+            inference_cfg, "mask_threshold", self._eval_mask_thresh,
+        ))
+
+        prob = out.get("point_mask_prob")
+        sample_idx = out["seg_sample_idx"].tolist()
+        view_idx = out["seg_view_idx"].tolist()
+        clouds = out.get("segmented_point_clouds") or []
+        instruction = batch[0]["instruction"]
+        for n, (b, v) in enumerate(zip(sample_idx, view_idx)):
+            payload = {
+                "sample_index": np.int64(b),
+                "view_index": np.int64(v),
+                "instruction": np.array(instruction[b], dtype=object),
+            }
+            if prob is not None:
+                payload["mask"] = (prob[n] > mask_threshold).cpu().numpy()
+                payload["mask_prob"] = prob[n].float().cpu().numpy()
+            if b < len(clouds):
+                payload["points"] = clouds[b].float().cpu().numpy()
+            out_path = os.path.join(
+                output_dir,
+                f"pred_{self.global_rank:02d}_{batch_idx:06d}_{n:03d}.npz",
+            )
+            np.savez_compressed(out_path, **payload)
+
+        if not bool(_cfg(inference_cfg, "save_full_point_cloud", False)):
+            return
+
+        full_points = out.get("metric_points", out.get("world_points"))
+        dense_masks = out.get("segmented_point_mask")
+        if full_points is None or dense_masks is None:
+            logger.warning(
+                "Full point-cloud output requested, but geometry or segmented "
+                "masks are unavailable; no cloud_*.npz files were written."
+            )
+            return
+
+        batch_size, num_views, height, width = full_points.shape[:4]
+        images = torch.stack([view["img"] for view in batch], dim=1).float()
+        if tuple(images.shape[-2:]) != (height, width):
+            images = F.interpolate(
+                images.flatten(0, 1),
+                size=(height, width),
+                mode="bilinear",
+                align_corners=False,
+            ).unflatten(0, (batch_size, num_views))
+        full_colors = (
+            images.permute(0, 1, 3, 4, 2).clamp(0, 1).mul(255).to(torch.uint8)
+        )
+
+        fused_masks = torch.zeros(
+            (batch_size, num_views, height, width),
+            dtype=torch.bool,
+            device=full_points.device,
+        )
+        for binding_index, (sample, view) in enumerate(zip(sample_idx, view_idx)):
+            fused_masks[sample, view] |= dense_masks[binding_index].to(
+                device=full_points.device, dtype=torch.bool,
+            )
+
+        scenes = batch[0].get("scene") or [""] * batch_size
+        for sample in range(batch_size):
+            sample_bindings = [
+                index for index, binding_sample in enumerate(sample_idx)
+                if binding_sample == sample
+            ]
+            cloud_payload = {
+                "sample_index": np.int64(sample),
+                "scene": np.array(scenes[sample], dtype=object),
+                "instruction": np.array(instruction[sample], dtype=object),
+                "view_indices": np.asarray(
+                    [view_idx[index] for index in sample_bindings], dtype=np.int64,
+                ),
+                "full_points": full_points[sample].float().cpu().numpy(),
+                "full_colors": full_colors[sample].cpu().numpy(),
+                "segmented_mask": fused_masks[sample].cpu().numpy(),
+            }
+            if sample < len(clouds):
+                cloud_payload["segmented_points"] = clouds[sample].float().cpu().numpy()
+            cloud_path = os.path.join(
+                output_dir,
+                f"cloud_{self.global_rank:02d}_{batch_idx:06d}_{sample:03d}.npz",
+            )
+            np.savez_compressed(cloud_path, **cloud_payload)
+
+    def on_save_checkpoint(self, checkpoint):
+        """Drop frozen SAM/Qwen base params; keep trainable LoRA/projector rows."""
+        sd = checkpoint.get("state_dict")
+        if not sd:
+            return
+        trainable = {name for name, param in self.named_parameters() if param.requires_grad}
+        for key in list(sd):
+            if key not in trainable:
+                del sd[key]
+
+    def configure_callbacks(self) -> Sequence[Callback] | pl.Callback:
+        """Configure standard periodic, best, and exception checkpoints.
+
+        Only trainable LoRA/projector rows are persisted (see
+        :meth:`on_save_checkpoint`). The shared TAO checkpointer ranks the best
+        checkpoints after validation by canonical point-cloud mIoU by default.
+        The periodic stream maintains a resumable ``*_latest.pth`` checkpoint.
+        """
+        results_dir = (
+            self.cfg["results_dir"]
+            if isinstance(self.cfg, dict)
+            else self.cfg.results_dir
+        )
+        checkpoint_interval = int(_cfg(self.train_cfg, "checkpoint_interval", 1) or 1)
+        checkpoint_interval_unit = str(_cfg(
+            self.train_cfg, "checkpoint_interval_unit", "epoch",
+        ))
+        status_logger_callback = TAOStatusLogger(results_dir, append=True)
+        ModelCheckpoint.FILE_EXTENSION = ".pth"
+        ModelCheckpoint.CHECKPOINT_EQUALS_CHAR = "_"
+        ModelCheckpoint.CHECKPOINT_NAME_LAST = f"{self.checkpoint_filename}_latest"
+        checkpoint_callback = ModelCheckpoint(
+            dirpath=results_dir,
+            monitor=None,
+            save_top_k=-1,
+            every_n_epochs=(
+                checkpoint_interval if checkpoint_interval_unit == "epoch" else None
+            ),
+            every_n_train_steps=(
+                checkpoint_interval if checkpoint_interval_unit == "step" else None
+            ),
+            save_on_train_epoch_end=True,
+            save_last="link",
+            filename="model_{epoch:03d}_{step:06d}",
+            enable_version_counter=False,
+        )
+        TAOExceptionCheckpoint.FILE_EXTENSION = ModelCheckpoint.FILE_EXTENSION
+        TAOExceptionCheckpoint.CHECKPOINT_NAME_LAST = ModelCheckpoint.CHECKPOINT_NAME_LAST
+        exception_checkpoint_callback = TAOExceptionCheckpoint(dirpath=results_dir)
+        callbacks = [status_logger_callback, checkpoint_callback, exception_checkpoint_callback]
+        return self._configure_best_checkpoint(callbacks, results_dir)
+
+    def configure_optimizers(self):
+        """AdamW over all trainable reasoning parameters, warmup then cosine."""
+        lr = float(_cfg(self.train_cfg, "lr", 1e-4))
+        min_lr = float(_cfg(self.train_cfg, "min_lr", 1e-6))
+        weight_decay = float(_cfg(self.train_cfg, "weight_decay", 0.05))
+
+        parameters = [
+            parameter
+            for parameter in self.model.parameters()
+            if parameter.requires_grad
+        ]
+        if not parameters:
+            raise ValueError("Reasoning model has no trainable parameters")
+        optimizer = torch.optim.AdamW(
+            parameters,
+            lr=lr,
+            weight_decay=weight_decay,
+        )
+
+        try:
+            total_steps = int(self.trainer.estimated_stepping_batches)
+        except Exception:
+            total_steps = 0
+        if total_steps <= 1:
+            return optimizer
+
+        num_epochs = int(_cfg(self.train_cfg, "num_epochs", 10) or 1)
+        warmup_epochs = float(_cfg(self.train_cfg, "warmup_epochs", 2.0) or 0)
+        warmup_steps = int(total_steps * min(max(warmup_epochs / max(num_epochs, 1), 0.0), 0.5))
+        min_ratio = max(0.0, min(min_lr / max(lr, 1e-12), 1.0))
+
+        def lr_lambda(step: int) -> float:
+            if warmup_steps > 0 and step < warmup_steps:
+                return float(step) / float(max(1, warmup_steps))
+            progress = float(step - warmup_steps) / float(max(1, total_steps - warmup_steps))
+            progress = min(1.0, max(0.0, progress))
+            return min_ratio + (1.0 - min_ratio) * 0.5 * (1.0 + math.cos(math.pi * progress))
+
+        scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+        return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "interval": "step"}}

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/qwen_builder.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/qwen_builder.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Factory helpers for the Qwen reasoning module."""
+
+from __future__ import annotations
+
+import torch
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning.qwen_vlm import (
+    DEFAULT_MODEL_ID,
+    Qwen3VLReasoner,
+)
+
+
+def cfg_get(cfg, key, default=None):
+    """Get a value from OmegaConf, argparse-style objects, or dicts."""
+    if cfg is None:
+        return default
+    if hasattr(cfg, key):
+        return getattr(cfg, key)
+    if isinstance(cfg, dict):
+        return cfg.get(key, default)
+    return default
+
+
+def build_qwen(qwen_cfg) -> Qwen3VLReasoner:
+    """Build the Qwen reasoner from the ``model.reasoning.qwen`` config block."""
+    lora_cfg = cfg_get(qwen_cfg, "lora", {})
+    dtype_str = str(cfg_get(qwen_cfg, "dtype", "float32")).lower()
+    dtype = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }.get(dtype_str, torch.float32)
+    return Qwen3VLReasoner(
+        model_id=cfg_get(qwen_cfg, "model_id", DEFAULT_MODEL_ID),
+        seg_token=cfg_get(qwen_cfg, "seg_token", "[SEG]"),
+        freeze_vision=bool(cfg_get(qwen_cfg, "freeze_vision", True)),
+        dtype=dtype,
+        attn_implementation=cfg_get(qwen_cfg, "attn_implementation", "sdpa"),
+        lora_r=int(cfg_get(lora_cfg, "r", 16)),
+        lora_alpha=int(cfg_get(lora_cfg, "alpha", 32)),
+        lora_dropout=float(cfg_get(lora_cfg, "dropout", 0.05)),
+        use_lora=bool(cfg_get(qwen_cfg, "use_lora", True)),
+    )

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/qwen_vlm.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/qwen_vlm.py
@@ -1,0 +1,371 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3-VL-4B wrapper for the embedding-as-mask reasoning pipeline.
+
+The wrapper adds a ``[SEG]`` token, freezes the vision tower, optionally applies
+LoRA, and exposes the last-layer ``[SEG]`` hidden states for the SAM3 prompt
+projector.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import torch
+from torch import Tensor, nn
+
+DEFAULT_MODEL_ID = "Qwen/Qwen3-VL-4B-Instruct"
+QWEN3_VL_4B_HIDDEN_SIZE = 2560
+ASSISTANT_PREFIX = "<|im_start|>assistant\n"
+DEFAULT_LORA_TARGETS = (
+    "q_proj", "k_proj", "v_proj", "o_proj",
+    "gate_proj", "up_proj", "down_proj",
+)
+LOCAL_MODEL_FILES = ("config.json", "preprocessor_config.json", "tokenizer_config.json")
+
+
+@dataclass
+class Qwen3VLReasonerOutput:
+    """Stable output contract consumed by the rest of NVPanoptix3Dv2-Reasoning.
+
+    Attributes:
+        lm_logits:    ``[B, T, V]`` autoregressive token logits (for text CE).
+        hidden:       ``[B, T, d_llm]`` last-layer hidden states.
+        input_ids:    ``[B, T]`` token ids (used to locate ``[SEG]`` positions).
+        attention_mask: ``[B, T]`` padding mask.
+        labels:       ``[B, T]`` text-CE targets (prompt tokens set to ``-100``),
+                      or ``None`` at inference.
+    """
+
+    lm_logits: Tensor
+    hidden: Tensor
+    input_ids: Tensor
+    attention_mask: Tensor
+    labels: Optional[Tensor] = None
+
+
+def extract_seg_hidden(
+    hidden: Tensor,
+    input_ids: Tensor,
+    seg_token_id: int,
+) -> Tuple[Tensor, Tensor]:
+    """Gather last-layer hidden states at every ``[SEG]`` position.
+
+    Pure function so it is testable without a model. Works with a variable number
+    of ``[SEG]`` tokens per sample (0, 1, or many): the returned ``batch_index``
+    maps each gathered row back to its sample, which the SAM3 prompt projector
+    uses to scatter rows into per-sample prompts.
+
+    Args:
+        hidden:    ``[B, T, d]`` last-layer hidden states.
+        input_ids: ``[B, T]`` token ids.
+        seg_token_id: vocabulary id of the ``[SEG]`` token.
+
+    Returns:
+        ``(h_seg, batch_index)`` where ``h_seg`` is ``[N, d]`` (N = total number of
+        ``[SEG]`` tokens across the batch) and ``batch_index`` is ``[N]`` (long).
+        Both are empty (N=0) when no ``[SEG]`` token is present.
+    """
+    if hidden.dim() != 3:
+        raise ValueError(f"hidden must be [B, T, d]; got shape {tuple(hidden.shape)}")
+    if input_ids.shape != hidden.shape[:2]:
+        raise ValueError(
+            f"input_ids {tuple(input_ids.shape)} must match hidden[:2] "
+            f"{tuple(hidden.shape[:2])}"
+        )
+    seg_pos = input_ids == seg_token_id          # [B, T] bool
+    batch_index, _ = torch.where(seg_pos)        # [N], [N]
+    h_seg = hidden[seg_pos]                       # [N, d]
+    return h_seg, batch_index.long()
+
+
+def bind_seg_to_views(
+    batch_index: Tensor,
+    seg_view_indices: Sequence[Sequence[int]],
+    num_views: int,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Map each ``[SEG]`` row to a ``(sample, view)`` pair.
+
+    :func:`extract_seg_hidden` returns rows row-major over ``(sample, token-pos)``, so within a
+    sample the ``[SEG]`` rows are already in answer (ascending picture) order. The j-th ``[SEG]``
+    of sample ``b`` therefore maps to ``seg_view_indices[b][j]``.
+
+    Args:
+        batch_index: ``[M]`` long, sample id per ``[SEG]`` row (from :func:`extract_seg_hidden`).
+        seg_view_indices: per-sample target views (ascending), length ``B``.
+        num_views: number of views ``S`` actually present in the batch tensors.
+
+    Returns:
+        ``(sample_idx[N], view_idx[N], keep[N])`` for the ``N`` rows that bind to a valid view.
+        Surplus ``[SEG]`` tokens (count > available views) and out-of-range views are dropped
+        (with a one-time warning), so ``N`` may be < ``M``.
+    """
+    device = batch_index.device
+    sample_rows: List[int] = []
+    view_rows: List[int] = []
+    keep_rows: List[int] = []
+    seen: Dict[int, int] = {}
+    dropped = 0
+    for row, b_raw in enumerate(batch_index.tolist()):
+        b = int(b_raw)
+        j = seen.get(b, 0)
+        seen[b] = j + 1
+        sv = seg_view_indices[b] if 0 <= b < len(seg_view_indices) else []
+        if j < len(sv) and 0 <= int(sv[j]) < int(num_views):
+            sample_rows.append(b)
+            view_rows.append(int(sv[j]))
+            keep_rows.append(row)
+        else:
+            dropped += 1
+    if dropped:
+        warnings.warn(
+            f"bind_seg_to_views: dropped {dropped} [SEG] token(s) with no matching/in-range "
+            f"view (num_views={num_views}).",
+            RuntimeWarning,
+        )
+    return (
+        torch.tensor(sample_rows, dtype=torch.long, device=device),
+        torch.tensor(view_rows, dtype=torch.long, device=device),
+        torch.tensor(keep_rows, dtype=torch.long, device=device),
+    )
+
+
+def find_answer_start(input_ids: Tensor, prefix_ids: Sequence[int]) -> int:
+    """Return the position immediately after the last assistant prefix."""
+    ids = input_ids.tolist()
+    prefix = list(prefix_ids)
+    for start in range(len(ids) - len(prefix), -1, -1):
+        if ids[start:start + len(prefix)] == prefix:
+            return start + len(prefix)
+    raise ValueError("Qwen3-VL input does not contain an assistant prefix.")
+
+
+def resolve_model_source(model_id: str) -> Tuple[str, bool]:
+    """Resolve a Hub model ID or validate a local model directory."""
+    model_id = str(model_id)
+    path = Path(model_id).expanduser()
+    if path.is_dir():
+        missing = [name for name in LOCAL_MODEL_FILES if not (path / name).is_file()]
+        if missing:
+            raise FileNotFoundError(
+                f"Qwen3-VL model directory {str(path)!r} is missing: {', '.join(missing)}"
+            )
+        return str(path), True
+
+    if path.is_absolute() or model_id.startswith((".", "~")):
+        raise FileNotFoundError(
+            f"Qwen3-VL model directory not found: {str(path)!r}. "
+            "Check the container mount and model.reasoning.qwen.model_id."
+        )
+
+    return model_id, False
+
+
+class Qwen3VLReasoner(nn.Module):
+    """Qwen3-VL-4B with segmentation tokens and optional LoRA."""
+
+    def __init__(
+        self,
+        model_id: str = DEFAULT_MODEL_ID,
+        seg_token: str = "[SEG]",
+        freeze_vision: bool = True,
+        # fp32 + sdpa is the safe runnable default (no autocast/flash-attn deps);
+        # switch to bf16 + flash_attention_2 once the pipeline runs, for memory.
+        dtype: torch.dtype = torch.float32,
+        attn_implementation: str = "sdpa",
+        lora_r: int = 16,
+        lora_alpha: int = 32,
+        lora_dropout: float = 0.05,
+        lora_targets: Sequence[str] = DEFAULT_LORA_TARGETS,
+        use_lora: bool = True,
+    ):
+        super().__init__()
+        self.processor, self.model = self.load_backbone(
+            model_id, dtype, attn_implementation,
+        )
+        self.tokenizer = self.processor.tokenizer
+        self._assistant_prefix_ids = self.tokenizer(
+            ASSISTANT_PREFIX,
+            add_special_tokens=False,
+        )["input_ids"]
+
+        # Extend the vocabulary with the segmentation token.
+        added = self.tokenizer.add_special_tokens(
+            {"additional_special_tokens": [seg_token]}
+        )
+        if added > 0:
+            self.model.resize_token_embeddings(len(self.tokenizer))
+        self._seg_token_id = self.tokenizer.convert_tokens_to_ids(seg_token)
+
+        if freeze_vision:
+            self.freeze_vision_tower()
+
+        if use_lora:
+            self.apply_lora(lora_r, lora_alpha, lora_dropout, list(lora_targets))
+
+    @staticmethod
+    def load_backbone(model_id, dtype, attn_implementation):
+        """Load and validate the native Qwen3-VL-4B model."""
+        try:
+            from transformers import Qwen3VLForConditionalGeneration, Qwen3VLProcessor
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "Qwen3-VL requires `transformers>=4.57.0,<5.0.0`."
+            ) from e
+
+        model_source, is_local = resolve_model_source(model_id)
+        load_kwargs = {"local_files_only": True} if is_local else {}
+        processor = Qwen3VLProcessor.from_pretrained(model_source, **load_kwargs)
+        model = Qwen3VLForConditionalGeneration.from_pretrained(
+            model_source,
+            dtype=dtype,
+            attn_implementation=attn_implementation,
+            **load_kwargs,
+        )
+        hidden_size = int(model.config.text_config.hidden_size)
+        if hidden_size != QWEN3_VL_4B_HIDDEN_SIZE:
+            raise ValueError(
+                "NVPanoptix3Dv2 requires Qwen3-VL-4B "
+                f"(hidden_size={QWEN3_VL_4B_HIDDEN_SIZE}), but {model_id!r} "
+                f"has hidden_size={hidden_size}."
+            )
+
+        return processor, model
+
+    def freeze_vision_tower(self) -> None:
+        """Freeze the Qwen3-VL visual encoder."""
+        for param in self.model.visual.parameters():
+            param.requires_grad = False
+
+    def apply_lora(self, r: int, alpha: int, dropout: float, targets: List[str]) -> None:
+        """Attach trainable LoRA adapters to the configured Qwen modules."""
+        try:
+            from peft import LoraConfig, get_peft_model
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "peft is required for LoRA fine-tuning of Qwen3-VL-4B. "
+                "Install with `pip install peft`."
+            ) from e
+
+        lora_cfg = LoraConfig(
+            r=r,
+            lora_alpha=alpha,
+            lora_dropout=dropout,
+            target_modules=targets,
+            # Keep the (resized) token embeddings + LM head fully trainable so the
+            # the new [SEG] row can learn; mirrors LISA's embed_tokens/lm_head.
+            modules_to_save=["embed_tokens", "lm_head"],
+            task_type="CAUSAL_LM",
+        )
+        self.model = get_peft_model(self.model, lora_cfg)
+
+    @property
+    def hidden_size(self) -> int:
+        """Qwen3-VL-4B language hidden width."""
+        return QWEN3_VL_4B_HIDDEN_SIZE
+
+    def build_inputs(
+        self,
+        images: Sequence[Sequence[object]],
+        instructions: Sequence[str],
+        answers: Optional[Sequence[str]] = None,
+        device: Optional[torch.device] = None,
+    ) -> Dict[str, Tensor]:
+        """Build processor inputs for a batch of (multi-image, instruction[, answer]).
+
+        Args:
+            images:       per-sample list of PIL images (the ``S`` views).
+            instructions: per-sample query string.
+            answers:      per-sample assistant answer (must contain ``[SEG]``);
+                          when provided, ``labels`` are built (teacher forcing).
+            device:       move tensors here.
+
+        Returns:
+            dict with ``input_ids``, ``attention_mask``, the model's image inputs
+            (e.g. ``pixel_values`` / ``image_grid_thw``), and ``labels`` (if
+            ``answers`` is given). Prompt tokens in ``labels`` are ``-100``.
+        """
+        if len(images) != len(instructions):
+            raise ValueError("images and instructions must have the same batch size")
+        if answers is not None and len(answers) != len(instructions):
+            raise ValueError("answers and instructions must have the same batch size")
+
+        def content(imgs, text):
+            return [{"type": "image", "image": im} for im in imgs] + [
+                {"type": "text", "text": text}
+            ]
+
+        messages = []
+        for i, (imgs, instr) in enumerate(zip(images, instructions)):
+            user = {"role": "user", "content": content(imgs, instr)}
+            conversation = [user]
+            if answers is not None:
+                conversation.append({"role": "assistant", "content": answers[i]})
+            messages.append(conversation)
+
+        # add_vision_id=True prepends a per-image identifier ("Picture i:") before
+        # each image, so the multi-view answer can reference "Picture i" and bind
+        # each [SEG] to its image (matches the reasonseg_mv data convention).
+        texts = [
+            self.processor.apply_chat_template(
+                message,
+                tokenize=False,
+                add_generation_prompt=answers is None,
+                add_vision_id=True,
+            )
+            for message in messages
+        ]
+        flat_images = [list(imgs) for imgs in images]
+        enc = self.processor(
+            text=texts,
+            images=flat_images,
+            return_tensors="pt",
+            padding=True,
+        )
+        if answers is not None:
+            labels = enc["input_ids"].clone()
+            for row, input_ids in enumerate(enc["input_ids"]):
+                answer_start = find_answer_start(input_ids, self._assistant_prefix_ids)
+                labels[row, :answer_start] = -100
+            labels[enc["attention_mask"] == 0] = -100
+            enc["labels"] = labels
+        return self.to_device(enc, device)
+
+    @staticmethod
+    def to_device(enc, device):
+        """Move tensor values in a processor encoding to ``device``."""
+        if device is None:
+            return dict(enc)
+        return {k: (v.to(device) if torch.is_tensor(v) else v) for k, v in enc.items()}
+
+    def forward(self, inputs: Dict[str, Tensor]) -> Qwen3VLReasonerOutput:
+        """Run the VLM and return logits + last-layer hidden states.
+
+        ``inputs`` is the dict from :meth:`build_inputs`. ``labels`` are carried
+        through to the output but the text-CE loss is computed in
+        the segmentation loss (so weighting/diagnostics stay in one place).
+        """
+        labels = inputs.get("labels", None)
+        model_inputs = {k: v for k, v in inputs.items() if k != "labels"}
+        out = self.model(
+            **model_inputs,
+            output_hidden_states=True,
+            use_cache=False,
+            return_dict=True,
+        )
+        hidden = out.hidden_states[-1]
+        return Qwen3VLReasonerOutput(
+            lm_logits=out.logits,
+            hidden=hidden,
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs["attention_mask"],
+            labels=labels,
+        )
+
+    def extract_seg_hidden(self, out: Qwen3VLReasonerOutput) -> Tuple[Tensor, Tensor]:
+        """Convenience wrapper around :func:`extract_seg_hidden`."""
+        return extract_seg_hidden(out.hidden, out.input_ids, self._seg_token_id)

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/reasoning_model.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/reasoning/reasoning_model.py
@@ -1,0 +1,423 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2-Reasoning: Qwen ``[SEG]`` embedding as a frozen SAM3 prompt.
+
+Multi-view reasoning segmentation (single-view is the ``S=1`` special case):
+
+    views + query -> Qwen3-VL -> hidden([SEG] per positive view) -> projector -> SAM3 prompt(s)
+    frozen SAM3 detector/segmentation head -> per-view instance masks
+    frozen VGGT -> dense world points -> per-view masks fused into one segmented point cloud
+
+Only Qwen LoRA/new-token rows and the ``[SEG]``->SAM prompt projector are
+trainable. SAM3 and VGGT are frozen. Each ``[SEG]`` is injected in SAM3's
+language-prompt tensor slot (replacing SAM's own text-encoder output) for its own
+view; VGGT then lifts the per-view masks into one fused segmented point cloud.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.metric_scale_head import (
+    MetricScaleHead,
+    apply_metric_scale,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning.qwen_vlm import (
+    Qwen3VLReasoner,
+    bind_seg_to_views,
+)
+
+
+def set_requires_grad(module: nn.Module, flag: bool) -> None:
+    """Set ``requires_grad`` for every parameter in ``module``."""
+    for param in module.parameters():
+        param.requires_grad = flag
+
+
+class SegToSAMPromptProjector(nn.Module):
+    """Project Qwen ``[SEG]`` hidden states to SAM3 prompt-space tokens.
+
+    SAM3 image uses a 256-d prompt/model dimension. Qwen3-VL-4B exposes a 2560-d
+    LLM hidden state, so the default projector is a small MLP ``4096 -> 4096 -> 256``.
+    Variable ``[SEG]`` counts are reduced to the first ``[SEG]`` per sample for
+    this single-target prototype.
+    """
+
+    def __init__(self, d_llm: int, d_sam: int = 256, hidden: int = 4096, dropout: float = 0.0):
+        super().__init__()
+        self.d_sam = int(d_sam)
+        self.proj = nn.Sequential(
+            nn.LayerNorm(d_llm),
+            nn.Linear(d_llm, hidden),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden, d_sam),
+            nn.LayerNorm(d_sam),
+        )
+        self.null_prompt = nn.Parameter(torch.zeros(1, d_sam))
+        nn.init.normal_(self.null_prompt, std=0.02)
+
+    def forward(self, h_seg: Tensor, batch_index: Tensor, batch_size: int) -> Tuple[Tensor, Tensor]:
+        """Return ``(prompt, valid)``.
+
+        Args:
+            h_seg: ``[N, d_llm]`` hidden states at all ``[SEG]`` positions.
+            batch_index: ``[N]`` sample id for each row of ``h_seg``.
+            batch_size: batch size ``B``.
+
+        Returns:
+            prompt: ``[1, B, 256]`` SAM language prompt tokens.
+            valid:  ``[B]`` bool, true when that sample had a real ``[SEG]``.
+        """
+        device = h_seg.device if h_seg.numel() else self.null_prompt.device
+        prompt = self.null_prompt.to(device).expand(batch_size, self.d_sam).clone()
+        valid = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        if h_seg.numel():
+            projected = self.proj(h_seg)
+            seen = set()
+            for row, b_raw in enumerate(batch_index.tolist()):
+                b = int(b_raw)
+                if b in seen or b < 0 or b >= batch_size:
+                    continue
+                prompt[b] = projected[row]
+                valid[b] = True
+                seen.add(b)
+        return prompt.unsqueeze(0), valid
+
+    def project_all(self, h_seg: Tensor) -> Tensor:
+        """Project every ``[SEG]`` hidden state to a SAM prompt token.
+
+        Unlike :meth:`forward` (which reduces to one prompt per sample), this returns one
+        prompt per ``[SEG]`` row, used by the multi-view path where each ``[SEG]`` prompts its
+        own view.
+
+        Args:
+            h_seg: ``[K, d_llm]`` hidden states (``K`` may be 0).
+
+        Returns:
+            ``[K, d_sam]`` prompt tokens.
+        """
+        if h_seg.numel() == 0:
+            return h_seg.new_zeros((0, self.d_sam))
+        return self.proj(h_seg)
+
+
+class NVPanoptix3Dv2Reasoning(nn.Module):
+    """Qwen reasoner, frozen SAM3 masks, and optional frozen VGGT point clouds."""
+
+    def __init__(
+        self,
+        qwen: Qwen3VLReasoner,
+        sam3_image_model: nn.Module,
+        projector: SegToSAMPromptProjector,
+        vggt_geometry_model: Optional[nn.Module] = None,
+        metric_depth_head: Optional[MetricScaleHead] = None,
+        sam_resolution: int = 1008,
+        point_mask_threshold: float = 0.5,
+        point_conf_threshold: Optional[float] = None,
+        freeze_sam: bool = True,
+        freeze_vggt: bool = True,
+    ):
+        super().__init__()
+        self.qwen = qwen
+        self.sam = sam3_image_model
+        self.vggt = vggt_geometry_model
+        self.metric_depth_head = metric_depth_head
+        self.projector = projector
+        self.sam_resolution = int(sam_resolution)
+        self.point_mask_threshold = float(point_mask_threshold)
+        self.point_conf_threshold = point_conf_threshold
+        if freeze_sam:
+            set_requires_grad(self.sam, False)
+        if self.vggt is not None and freeze_vggt:
+            set_requires_grad(self.vggt, False)
+        # SAM3 has mixed checkpoint dtypes in some environments; fp32 is the
+        # most stable baseline for the projector experiment.
+        self.sam.float()
+        self.sam.eval()
+        if self.vggt is not None:
+            self.vggt.float()
+            self.vggt.eval()
+
+    @staticmethod
+    def lift_bindings_to_point_clouds(
+        pred_masks: Tensor,
+        pred_logits: Tensor,
+        world_points: Tensor,
+        sample_idx: Tensor,
+        view_idx: Tensor,
+        batch_size: int,
+        world_points_conf: Optional[Tensor] = None,
+        mask_threshold: float = 0.5,
+        conf_threshold: Optional[float] = None,
+    ) -> Tuple[List[Tensor], Tensor, Tensor, Tensor]:
+        """Lift each ``(binding)`` mask into its own view's VGGT points and fuse per sample.
+
+        Args:
+            pred_masks: ``[N,Q,h,w]`` SAM mask logits (one row per binding).
+            pred_logits: ``[N,Q]`` SAM query logits.
+            world_points: ``[B,S,H,W,3]`` dense 3D points (shared coordinate frame).
+            sample_idx: ``[N]`` sample id per binding.
+            view_idx: ``[N]`` view id per binding.
+            batch_size: ``B``.
+            world_points_conf: optional ``[B,S,H,W]`` (or ``[B,S,H,W,1]``) confidence map.
+            mask_threshold: foreground threshold applied after sigmoid.
+            conf_threshold: optional VGGT confidence gate.
+
+        Returns:
+            ``(point_clouds, dense_mask, selected_query, prob)``: per-sample fused clouds
+            (list length ``B``), dense boolean selection ``[N,H,W]``, selected query ids ``[N]``,
+            and resized mask probabilities ``[N,H,W]``.
+        """
+        if pred_masks.dim() != 4:
+            raise ValueError(f"pred_masks must be [N,Q,h,w], got {tuple(pred_masks.shape)}")
+        if world_points.dim() != 5 or world_points.shape[-1] != 3:
+            raise ValueError(
+                f"world_points must be [B,S,H,W,3], got {tuple(world_points.shape)}"
+            )
+        N = pred_masks.shape[0]
+        _, _, H, W, _ = world_points.shape
+        if N == 0:
+            empty = pred_masks.new_zeros((0, H, W))
+            return (
+                [world_points.new_zeros((0, 3)) for _ in range(batch_size)],
+                empty.bool(),
+                pred_masks.new_zeros((0,), dtype=torch.long),
+                empty,
+            )
+        selected_query = pred_logits.float().argmax(dim=1)  # [N]
+        selected = pred_masks[torch.arange(N, device=pred_masks.device), selected_query]  # [N,h,w]
+        prob = F.interpolate(
+            selected.unsqueeze(1).float(), size=(H, W), mode="bilinear", align_corners=False
+        ).sigmoid()[:, 0].to(world_points.device)  # [N,H,W]
+        wp = world_points[sample_idx, view_idx]  # [N,H,W,3]
+        valid_xyz = torch.isfinite(wp).all(dim=-1)  # [N,H,W]
+        dense = (prob > float(mask_threshold)) & valid_xyz
+        if world_points_conf is not None and conf_threshold is not None:
+            conf = world_points_conf
+            if conf.dim() == 5 and conf.shape[-1] == 1:
+                conf = conf[..., 0]
+            conf_sel = conf[sample_idx, view_idx].to(world_points.device)  # [N,H,W]
+            dense = dense & (conf_sel >= float(conf_threshold))
+        point_clouds: List[Tensor] = []
+        for b in range(batch_size):
+            rows = (sample_idx == b).nonzero(as_tuple=False).flatten().tolist()
+            if rows:
+                pts = torch.cat([wp[r][dense[r]] for r in rows], dim=0).detach()
+            else:
+                pts = world_points.new_zeros((0, 3))
+            point_clouds.append(pts)
+        return point_clouds, dense, selected_query, prob
+
+    def sam_forward_with_prompt(self, images: Tensor, prompt: Tensor) -> Dict[str, Tensor]:
+        """Run frozen SAM3 using ``prompt`` as its language-feature tensor.
+
+        Args:
+            images: ``[B,3,H,W]`` in [0, 1].
+            prompt: ``[1,B,256]`` projected Qwen prompt.
+
+        Returns:
+            dict containing SAM3 ``pred_masks`` ``[B,Q,h,w]``, ``pred_logits``
+            ``[B,Q]``, and optional ``presence_logits`` ``[B]``.
+        """
+        from sam3.model.data_misc import FindStage
+
+        B = int(images.shape[0])
+        device = next(self.sam.parameters()).device
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+        images = images.to(device)
+        prompt = prompt.to(device)
+
+        x = F.interpolate(
+            images,
+            size=(self.sam_resolution, self.sam_resolution),
+            mode="bilinear",
+            align_corners=False,
+        )
+        x = (x - 0.5) / 0.5
+
+        self.sam.eval()
+        autocast_dev = "cuda" if x.is_cuda else "cpu"
+        with torch.no_grad(), torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16):
+            backbone_out = self.sam.backbone.forward_image(x)
+
+        # Override SAM's text encoder output with the projected Qwen [SEG] token.
+        backbone_out["language_features"] = prompt
+        backbone_out["language_mask"] = torch.zeros(B, 1, dtype=torch.bool, device=device)
+
+        find_input = FindStage(
+            img_ids=torch.arange(B, device=device, dtype=torch.long),
+            text_ids=torch.arange(B, device=device, dtype=torch.long),
+            input_boxes=None,
+            input_boxes_mask=None,
+            input_boxes_label=None,
+            input_points=None,
+            input_points_mask=None,
+        )
+        geometric_prompt = self.sam._get_dummy_prompt(num_prompts=B)
+
+        # Keep autograd enabled here: SAM parameters are frozen, but gradients
+        # must flow from SAM mask loss back to the projected Qwen prompt.
+        with torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16):
+            out = self.sam.forward_grounding(
+                backbone_out=backbone_out,
+                find_input=find_input,
+                find_target=None,
+                geometric_prompt=geometric_prompt,
+            )
+
+        pred_logits = out["pred_logits"].squeeze(-1).float()
+        presence = out.get("presence_logit_dec")
+        if presence is not None:
+            presence = presence.squeeze(-1).float()
+        return {
+            "pred_masks": out["pred_masks"].float(),
+            "pred_logits": pred_logits,
+            "presence_logits": presence,
+        }
+
+    def vggt_forward(self, images: Tensor) -> Optional[Dict[str, object]]:
+        """Run frozen VGGT and lift SAM masks into dense point clouds later."""
+        if self.vggt is None:
+            return None
+        device = next(self.vggt.parameters()).device
+        x = images.to(device)
+        self.vggt.eval()
+        autocast_dev = "cuda" if x.is_cuda else "cpu"
+        with torch.no_grad(), torch.autocast(device_type=autocast_dev, dtype=torch.bfloat16):
+            out = self.vggt(x)
+        return {
+            "vggt_feats": out.get("vggt_feats"),
+            "world_points": out.get("world_points"),
+            "world_points_conf": out.get("world_points_conf"),
+            "depth": out.get("depth"),
+            "depth_conf": out.get("depth_conf"),
+            "pose_enc": out.get("pose_enc"),
+        }
+
+    def apply_metric_depth_head(self, vggt_out: Dict[str, object]) -> Dict[str, object]:
+        """Expose metric outputs using the shared metric-scale-head convention."""
+        metric_head = self.metric_depth_head
+        if metric_head is None:
+            return {}
+        depth = vggt_out.get("depth")
+        pose_enc = vggt_out.get("pose_enc")
+        vggt_feats = vggt_out.get("vggt_feats")
+        world_points = vggt_out.get("world_points")
+        if depth is None or pose_enc is None or vggt_feats is None:
+            return {}
+
+        H_d, W_d = depth.shape[2], depth.shape[3]
+        params = metric_head(
+            vggt_feats=vggt_feats,
+            rel_depth=depth,
+            pose_enc=pose_enc,
+            image_size_hw=(H_d, W_d),
+        )
+        metric_out = {
+            "scale_shift_params": params,
+            "intrinsics": params["intrinsics"],
+            "metric_depth": apply_metric_scale(depth, params),
+        }
+        if world_points is not None:
+            metric_out["metric_points"] = (
+                world_points * params["scale"][:, :, None, None, None]
+            )
+        return metric_out
+
+    def forward(
+        self,
+        images: Tensor,
+        qwen_inputs: Dict[str, Tensor],
+        seg_view_indices: Optional[List[List[int]]] = None,
+    ) -> Dict[str, object]:
+        """Forward for multi-view reasoning segmentation (single-view is the ``S=1`` case).
+
+        Each ``[SEG]`` token prompts SAM3 on its own (positive) view; all ``(sample, view)``
+        bindings are flattened into one SAM3 pseudo-batch of size ``N``. VGGT runs once over all
+        ``S`` views and the per-view masks are fused into one point cloud per sample.
+
+        Args:
+            images: ``[B,S,3,H,W]`` or ``[B,3,H,W]`` in [0,1].
+            qwen_inputs: output of :meth:`Qwen3VLReasoner.build_inputs` (all ``S`` views).
+            seg_view_indices: per-sample target views (ascending), one inner list per sample;
+                the j-th ``[SEG]`` of a sample binds to ``seg_view_indices[b][j]``. Defaults to
+                ``[[0]] * B`` (single-view / one-``[SEG]`` behavior).
+        """
+        if images.dim() == 4:
+            images = images.unsqueeze(1)                  # [B,1,3,H,W]
+        elif images.dim() != 5:
+            raise ValueError(f"images must be [B,S,3,H,W] or [B,3,H,W], got {tuple(images.shape)}")
+        B, S = images.shape[:2]
+        device = images.device
+        if seg_view_indices is None:
+            seg_view_indices = [[0] for _ in range(B)]
+
+        qout = self.qwen(qwen_inputs)
+        h_seg, batch_index = self.qwen.extract_seg_hidden(qout)          # [M,d], [M]
+        sample_idx, view_idx, keep = bind_seg_to_views(batch_index, seg_view_indices, S)
+        N = int(keep.numel())
+
+        dec_dtype = next(self.projector.parameters()).dtype
+        if N > 0:
+            prompts = self.projector.project_all(h_seg[keep].to(dec_dtype))  # [N,256]
+            prompt = prompts.unsqueeze(0)                                    # [1,N,256]
+            img_sel = images[sample_idx, view_idx]                           # [N,3,H,W]
+            sam_out = self.sam_forward_with_prompt(img_sel, prompt)
+        else:
+            prompt = None
+            sam_out = {
+                "pred_masks": images.new_zeros((0, 1, 1, 1)),
+                "pred_logits": images.new_zeros((0, 1)),
+                "presence_logits": None,
+            }
+
+        sample_has_seg = torch.zeros(B, dtype=torch.bool, device=device)
+        if N > 0:
+            sample_has_seg[sample_idx] = True
+
+        out = {
+            "lm_logits": qout.lm_logits,
+            "labels": qout.labels,
+            "h_seg": h_seg,
+            "batch_index": batch_index,
+            "sam_prompt": prompt,
+            "seg_valid": torch.ones(N, dtype=torch.bool, device=device),
+            "seg_sample_idx": sample_idx,
+            "seg_view_idx": view_idx,
+            "sample_has_seg": sample_has_seg,
+            **sam_out,
+        }
+        vggt_out = self.vggt_forward(images)
+        if vggt_out is not None:
+            out.update(vggt_out)
+            out.update(self.apply_metric_depth_head(vggt_out))
+
+        point_source = out.get("metric_points", out.get("world_points"))
+        if point_source is not None:
+            point_clouds, point_mask, selected_query, point_mask_prob = self.lift_bindings_to_point_clouds(
+                pred_masks=out["pred_masks"],
+                pred_logits=out["pred_logits"],
+                world_points=point_source,
+                sample_idx=sample_idx,
+                view_idx=view_idx,
+                batch_size=B,
+                world_points_conf=out.get("world_points_conf"),
+                mask_threshold=self.point_mask_threshold,
+                conf_threshold=self.point_conf_threshold,
+            )
+            out.update({
+                "segmented_point_clouds": point_clouds,
+                "segmented_point_mask": point_mask,       # [N,H,W]
+                "selected_query": selected_query,         # [N]
+                "point_mask_prob": point_mask_prob,       # [N,H,W]
+            })
+            if "metric_points" in out:
+                out["metric_segmented_point_clouds"] = point_clouds
+        return out

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""VGGT module as the backbone of the NVPanoptix3Dv2 model."""
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models.vggt import VGGT
+
+__all__ = ["VGGT"]

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Portions of this code are based on the VGGT project by Facebook Research (Meta):
+# https://github.com/facebookresearch/vggt
+
+"""Model module for the VGGT backbone of the NVPanoptix3Dv2 model."""
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models.aggregator import (
+    Aggregator,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models.vggt import VGGT
+
+__all__ = ["VGGT", "Aggregator"]

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/aggregator.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/aggregator.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Aggregator module for the VGGT model."""
+
+import logging
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+from torch.utils.checkpoint import checkpoint
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.block import Block
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.rope import (
+    PositionGetter,
+    RotaryPositionEmbedding2D,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.vision_transformer import (
+    vit_base,
+    vit_giant2,
+    vit_large,
+    vit_small,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.models.aggregator import (
+    slice_expand_and_flatten,
+)
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models.patch_embed import (
+    PatchEmbed,
+)
+
+logger = logging.getLogger(__name__)
+
+_RESNET_MEAN = [0.485, 0.456, 0.406]
+_RESNET_STD = [0.229, 0.224, 0.225]
+
+
+class Aggregator(nn.Module):
+    """
+    The Aggregator applies alternating-attention over input frames,
+    as described in VGGT: Visual Geometry Grounded Transformer.
+
+    Remember to set model.train() to enable gradient checkpointing to reduce memory usage.
+
+    Args:
+        img_size (int): Image size in pixels.
+        patch_size (int): Size of each patch for PatchEmbed.
+        embed_dim (int): Dimension of the token embeddings.
+        depth (int): Number of blocks.
+        num_heads (int): Number of attention heads.
+        mlp_ratio (float): Ratio of MLP hidden dim to embedding dim.
+        num_register_tokens (int): Number of register tokens.
+        block_fn (nn.Module): The block type used for attention (Block by default).
+        qkv_bias (bool): Whether to include bias in QKV projections.
+        proj_bias (bool): Whether to include bias in the output projection.
+        ffn_bias (bool): Whether to include bias in MLP layers.
+        patch_embed (str): Type of patch embed. e.g., "conv" or "dinov2_vitl14_reg".
+        aa_order (list[str]): The order of alternating attention, e.g. ["frame", "global"].
+        aa_block_size (int): How many blocks to group under each attention type before switching. If not necessary, set to 1.
+        qk_norm (bool): Whether to apply QK normalization.
+        rope_freq (int): Base frequency for rotary embedding. -1 to disable.
+        init_values (float): Init scale for layer scale.
+    """
+
+    def __init__(
+        self,
+        img_size=518,
+        patch_size=14,
+        embed_dim=1024,
+        depth=24,
+        num_heads=16,
+        mlp_ratio=4.0,
+        num_register_tokens=4,
+        block_fn=Block,
+        qkv_bias=True,
+        proj_bias=True,
+        ffn_bias=True,
+        patch_embed="dinov2_vitl14_reg",
+        aa_order=("frame", "global"),
+        aa_block_size=1,
+        qk_norm=True,
+        rope_freq=100,
+        init_values=0.01,
+    ):
+        super().__init__()
+
+        self.build_patch_embed(patch_embed, img_size, patch_size, num_register_tokens, embed_dim=embed_dim)
+
+        # Initialize rotary position embedding if frequency > 0
+        self.rope = RotaryPositionEmbedding2D(frequency=rope_freq) if rope_freq > 0 else None
+        self.position_getter = PositionGetter() if self.rope is not None else None
+
+        self.frame_blocks = nn.ModuleList(
+            [
+                block_fn(
+                    dim=embed_dim,
+                    num_heads=num_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=qkv_bias,
+                    proj_bias=proj_bias,
+                    ffn_bias=ffn_bias,
+                    init_values=init_values,
+                    qk_norm=qk_norm,
+                    rope=self.rope,
+                )
+                for _ in range(depth)
+            ]
+        )
+
+        self.global_blocks = nn.ModuleList(
+            [
+                block_fn(
+                    dim=embed_dim,
+                    num_heads=num_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=qkv_bias,
+                    proj_bias=proj_bias,
+                    ffn_bias=ffn_bias,
+                    init_values=init_values,
+                    qk_norm=qk_norm,
+                    rope=self.rope,
+                )
+                for _ in range(depth)
+            ]
+        )
+
+        self.depth = depth
+        self.aa_order = aa_order
+        self.patch_size = patch_size
+        self.aa_block_size = aa_block_size
+
+        # Validate that depth is divisible by aa_block_size
+        if self.depth % self.aa_block_size != 0:
+            raise ValueError(f"depth ({depth}) must be divisible by aa_block_size ({aa_block_size})")
+
+        self.aa_block_num = self.depth // self.aa_block_size
+
+        # Note: We have two camera tokens, one for the first frame and one for the rest
+        # The same applies for register tokens
+        self.camera_token = nn.Parameter(torch.randn(1, 2, 1, embed_dim))
+        self.register_token = nn.Parameter(torch.randn(1, 2, num_register_tokens, embed_dim))
+
+        # The patch tokens start after the camera and register tokens
+        self.patch_start_idx = 1 + num_register_tokens
+
+        # Initialize parameters with small values
+        nn.init.normal_(self.camera_token, std=1e-6)
+        nn.init.normal_(self.register_token, std=1e-6)
+
+        # Register normalization constants as buffers
+        for name, value in (("_resnet_mean", _RESNET_MEAN), ("_resnet_std", _RESNET_STD)):
+            self.register_buffer(name, torch.FloatTensor(value).view(1, 1, 3, 1, 1), persistent=False)
+
+        self.use_reentrant = False  # hardcoded to False
+
+    def build_patch_embed(
+        self,
+        patch_embed,
+        img_size,
+        patch_size,
+        num_register_tokens,
+        interpolate_antialias=True,
+        interpolate_offset=0.0,
+        block_chunks=0,
+        init_values=1.0,
+        embed_dim=1024,
+    ):
+        """
+        Build the patch embed layer. If 'conv', we use a
+        simple PatchEmbed conv layer. Otherwise, we use a vision transformer.
+        """
+        if "conv" in patch_embed:
+            self.patch_embed = PatchEmbed(
+                patch_size=patch_size,
+                in_chans=3,
+                embed_dim=embed_dim,
+            )
+        else:
+            vit_models = {
+                "dinov2_vitl14_reg": vit_large,
+                "dinov2_vitb14_reg": vit_base,
+                "dinov2_vits14_reg": vit_small,
+                "dinov2_vitg2_reg": vit_giant2,
+            }
+
+            self.patch_embed = vit_models[patch_embed](
+                img_size=img_size,
+                patch_size=patch_size,
+                num_register_tokens=num_register_tokens,
+                interpolate_antialias=interpolate_antialias,
+                interpolate_offset=interpolate_offset,
+                block_chunks=block_chunks,
+                init_values=init_values,
+            )
+
+            # Disable gradient updates for mask token
+            if hasattr(self.patch_embed, "mask_token"):
+                self.patch_embed.mask_token.requires_grad_(False)
+
+    def forward(self, images: torch.Tensor) -> Tuple[List[torch.Tensor], int]:
+        """
+        Args:
+            images (torch.Tensor): Input images with shape [B, S, 3, H, W], in range [0, 1].
+                B: batch size, S: sequence length, 3: RGB channels, H: height, W: width
+
+        Returns:
+            (list[torch.Tensor], int):
+                The list of outputs from the attention blocks,
+                and the patch_start_idx indicating where patch tokens begin.
+        """
+        B, S, C_in, H, W = images.shape
+
+        if C_in != 3:
+            raise ValueError(f"Expected 3 input channels, got {C_in}")
+
+        # Normalize images and reshape for patch embed
+        images = (images - self._resnet_mean) / self._resnet_std
+
+        # Reshape to [B*S, C, H, W] for patch embedding
+        images = images.view(B * S, C_in, H, W)
+        patch_tokens = self.patch_embed(images)
+
+        if isinstance(patch_tokens, dict):
+            patch_tokens = patch_tokens["x_norm_patchtokens"]
+
+        # Expand camera and register tokens to match batch size and sequence length
+        camera_token = slice_expand_and_flatten(self.camera_token, B, S)
+        register_token = slice_expand_and_flatten(self.register_token, B, S)
+
+        # Concatenate special tokens with patch tokens
+        tokens = torch.cat([camera_token, register_token, patch_tokens], dim=1)
+
+        pos = None
+        if self.rope is not None:
+            pos = self.position_getter(B * S, H // self.patch_size, W // self.patch_size, device=images.device)
+
+        if self.patch_start_idx > 0:
+            # do not use position embedding for special tokens (camera and register tokens)
+            # so set pos to 0 for the special tokens
+            pos = pos + 1
+            pos_special = torch.zeros(B * S, self.patch_start_idx, 2).to(images.device).to(pos.dtype)
+            pos = torch.cat([pos_special, pos], dim=1)
+
+        # update P because we added special tokens
+        _, P, C = tokens.shape
+
+        frame_idx = 0
+        global_idx = 0
+        output_list = []
+
+        for _ in range(self.aa_block_num):
+            for attn_type in self.aa_order:
+                if attn_type == "frame":
+                    tokens, frame_idx, frame_intermediates = self.process_frame_attention(
+                        tokens, B, S, P, C, frame_idx, pos=pos
+                    )
+                elif attn_type == "global":
+                    tokens, global_idx, global_intermediates = self.process_global_attention(
+                        tokens, B, S, P, C, global_idx, pos=pos
+                    )
+                else:
+                    raise ValueError(f"Unknown attention type: {attn_type}")
+
+            for i in range(len(frame_intermediates)):
+                # concat frame and global intermediates, [B x S x P x 2C]
+                concat_inter = torch.cat([frame_intermediates[i], global_intermediates[i]], dim=-1)
+                output_list.append(concat_inter)
+
+        return output_list, self.patch_start_idx, patch_tokens.view(B, S, -1, C)  # patch_tokens is the dinov2 features, shape [B, S, P, C]
+
+    def process_frame_attention(self, tokens, B, S, P, C, frame_idx, pos=None):
+        """
+        Process frame attention blocks. We keep tokens in shape (B*S, P, C).
+        """
+        # If needed, reshape tokens or positions:
+        if tokens.shape != (B * S, P, C):
+            tokens = tokens.view(B, S, P, C).view(B * S, P, C)
+
+        if pos is not None and pos.shape != (B * S, P, 2):
+            pos = pos.view(B, S, P, 2).view(B * S, P, 2)
+
+        intermediates = []
+
+        # by default, self.aa_block_size=1, which processes one block at a time
+        for _ in range(self.aa_block_size):
+            if self.training:
+                tokens = checkpoint(self.frame_blocks[frame_idx], tokens, pos, use_reentrant=self.use_reentrant)
+            else:
+                tokens = self.frame_blocks[frame_idx](tokens, pos=pos)
+            frame_idx += 1
+            intermediates.append(tokens.view(B, S, P, C))
+
+        return tokens, frame_idx, intermediates
+
+    def process_global_attention(self, tokens, B, S, P, C, global_idx, pos=None):
+        """
+        Process global attention blocks. We keep tokens in shape (B, S*P, C).
+        """
+        if tokens.shape != (B, S * P, C):
+            tokens = tokens.view(B, S, P, C).view(B, S * P, C)
+
+        if pos is not None and pos.shape != (B, S * P, 2):
+            pos = pos.view(B, S, P, 2).view(B, S * P, 2)
+
+        intermediates = []
+
+        # by default, self.aa_block_size=1, which processes one block at a time
+        for _ in range(self.aa_block_size):
+            if self.training:
+                tokens = checkpoint(self.global_blocks[global_idx], tokens, pos, use_reentrant=self.use_reentrant)
+            else:
+                tokens = self.global_blocks[global_idx](tokens, pos=pos)
+            global_idx += 1
+            intermediates.append(tokens.view(B, S, P, C))
+
+        return tokens, global_idx, intermediates

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/patch_embed.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/patch_embed.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+
+# References:
+#   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
+#   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/patch_embed.py
+
+"""Patch embedding module for the VGGT model."""
+
+from typing import Callable, Optional, Tuple, Union
+
+from torch import Tensor
+import torch.nn as nn
+
+
+def make_2tuple(x):
+    """Broadcast an int to a 2-tuple, or pass a 2-tuple through unchanged."""
+    if isinstance(x, tuple):
+        if len(x) != 2:
+            raise ValueError(f"Expected a 2-tuple, got {x!r}")
+        return x
+
+    if not isinstance(x, int):
+        raise TypeError(f"Expected an int or 2-tuple, got {type(x).__name__}")
+    return (x, x)
+
+
+class PatchEmbed(nn.Module):
+    """
+    2D image to patch embedding: (B,C,H,W) -> (B,N,D)
+
+    Args:
+        patch_size: Patch token size.
+        in_chans: Number of input image channels.
+        embed_dim: Number of linear projection output channels.
+        norm_layer: Normalization layer.
+    """
+
+    def __init__(
+        self,
+        patch_size: Union[int, Tuple[int, int]] = 16,
+        in_chans: int = 3,
+        embed_dim: int = 768,
+        norm_layer: Optional[Callable] = None,
+        flatten_embedding: bool = True,
+    ) -> None:
+        super().__init__()
+
+        patch_HW = make_2tuple(patch_size)
+
+        self.patch_size = patch_HW
+        self.embed_dim = embed_dim
+
+        self.flatten_embedding = flatten_embedding
+
+        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=patch_HW, stride=patch_HW)
+        self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass."""
+        _, _, H, W = x.shape
+        patch_H, patch_W = self.patch_size
+
+        if H % patch_H != 0:
+            raise ValueError(
+                f"Input height {H} is not divisible by patch height {patch_H}"
+            )
+        if W % patch_W != 0:
+            raise ValueError(
+                f"Input width {W} is not divisible by patch width {patch_W}"
+            )
+
+        x = self.proj(x)  # B C H W
+        H, W = x.size(2), x.size(3)
+        x = x.flatten(2).transpose(1, 2)  # B HW C
+        x = self.norm(x)
+        if not self.flatten_embedding:
+            x = x.reshape(-1, H, W, self.embed_dim)  # B H W C
+        return x

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/vggt.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/vggt/models/vggt.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""VGGT module for the VGGT model."""
+
+import torch
+import torch.nn as nn
+from huggingface_hub import PyTorchModelHubMixin  # used for model hub
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.heads.camera_head import (
+    CameraHead,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.heads.dpt_head import DPTHead
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models.aggregator import (
+    Aggregator,
+)
+
+
+class VGGT(nn.Module, PyTorchModelHubMixin):
+    """VGGT model
+
+    Args:
+        img_size (int): Input image size. Default is 518.
+        patch_size (int): Patch size. Default is 14.
+        embed_dim (int): Embedding dimension. Default is 1024.
+        enable_camera (bool): Whether to enable the camera-pose head. Default is True.
+        enable_point (bool): Whether to enable the world-point head. Default is True.
+        enable_depth (bool): Whether to enable the depth head. Default is True.
+
+    Note:
+        Upstream VGGT also ships a point-tracking head. Neither NVPanoptix3Dv2
+        variant tracks points, so that head is not vendored here and its weights
+        are dropped when loading an upstream checkpoint.
+    """
+
+    def __init__(self, img_size=518, patch_size=14, embed_dim=1024,
+                 enable_camera=True, enable_point=True, enable_depth=True):
+        super().__init__()
+
+        self.aggregator = Aggregator(img_size=img_size, patch_size=patch_size, embed_dim=embed_dim)
+
+        self.camera_head = CameraHead(dim_in=2 * embed_dim) if enable_camera else None
+        self.point_head = DPTHead(dim_in=2 * embed_dim, output_dim=4, activation="inv_log", conf_activation="expp1") if enable_point else None
+        self.depth_head = DPTHead(dim_in=2 * embed_dim, output_dim=2, activation="exp", conf_activation="expp1") if enable_depth else None
+
+    def forward(self, images: torch.Tensor):
+        """
+        Forward pass of the VGGT model.
+
+        Args:
+            images (torch.Tensor): Input images with shape [S, 3, H, W] or [B, S, 3, H, W], in range [0, 1].
+                B: batch size, S: sequence length, 3: RGB channels, H: height, W: width
+
+        Returns:
+            dict: A dictionary containing the following predictions:
+                - pose_enc (torch.Tensor): Camera pose encoding with shape [B, S, 9] (from the last iteration)
+                - depth (torch.Tensor): Predicted depth maps with shape [B, S, H, W, 1]
+                - depth_conf (torch.Tensor): Confidence scores for depth predictions with shape [B, S, H, W]
+                - world_points (torch.Tensor): 3D world coordinates for each pixel with shape [B, S, H, W, 3]
+                - world_points_conf (torch.Tensor): Confidence scores for world points with shape [B, S, H, W]
+                - dino_feats (torch.Tensor): DINOv2 patch features with shape [B, S, P, C]
+                - vggt_feats (torch.Tensor): Final aggregator patch features with shape [B, S, P, 2C]
+        """
+        if images.dim() == 4:
+            images = images.unsqueeze(0)
+        elif images.dim() != 5:
+            raise ValueError(
+                "images must be [S,3,H,W] or [B,S,3,H,W], got "
+                f"shape {tuple(images.shape)}"
+            )
+
+        aggregated_tokens_list, patch_start_idx, dino_feats = self.aggregator(images)
+        vggt_feats = aggregated_tokens_list[-1][:, :, patch_start_idx:]  # shape [B, S, P, 2C]
+
+        predictions = {
+            "dino_feats": dino_feats,
+            "vggt_feats": vggt_feats,
+        }
+
+        with torch.amp.autocast("cuda", enabled=False):
+            if self.camera_head is not None:
+                pose_enc_list = self.camera_head(aggregated_tokens_list)
+                predictions["pose_enc"] = pose_enc_list[-1]  # pose encoding of the last iteration
+
+            if self.depth_head is not None:
+                depth, depth_conf = self.depth_head(
+                    aggregated_tokens_list, images=images, patch_start_idx=patch_start_idx
+                )
+                predictions["depth"] = depth
+                predictions["depth_conf"] = depth_conf
+
+            if self.point_head is not None:
+                pts3d, pts3d_conf = self.point_head(
+                    aggregated_tokens_list, images=images, patch_start_idx=patch_start_idx
+                )
+                predictions["world_points"] = pts3d
+                predictions["world_points_conf"] = pts3d_conf
+
+        return predictions


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->
Add the NVPanoptix3Dv2 model implementation with:

- A shared VGGT geometry backbone (mainly inherit from v1) and metric-scale head.
- A panoptic variant using DINO/VGGT feature fusion, LoftUp upscaling, SigLIP embeddings, and multi-view mask decoding.
- A reasoning variant connecting Qwen `[SEG]` embeddings to frozen SAM3 and VGGT components.
- Reuse of compatible NVPanoptix3D and Mask2Former components to avoid duplicated implementations.

### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->

NVPanoptix3Dv2 requires model implementations for its panoptic and reasoning variants. This change provides the trainable model components, checkpoint handling, optimization setup, validation metrics, inference outputs, and shared geometry processing needed by the corresponding configurations and dataloaders.


### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->

Part of TAOVN-1251

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->

Yes.

Previously, TAO PyTorch did not contain an NVPanoptix3Dv2 model module. This PR introduces model support for two variants selected through `model.model_type`:

- `panoptic`: open-vocabulary multi-view panoptic segmentation and metric geometry.
- `reasoning`: Qwen-guided SAM3 segmentation with optional VGGT point-cloud output.

### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->

The complete model folder was compiled and checked with the repository-configured static hooks:

```bash
$ python -m compileall -q \
    nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model

$ shopt -s globstar nullglob
$ model_files=(nvidia_tao_pytorch/cv/nvpanoptix3d_v2/model/**/*.py)
$ pre-commit run --files "${model_files[@]}"
```

Results:

```text
TruffleHog secret scan...................................................Passed
dependency change guard..............................(no files to check)Skipped
license header...........................................................Passed
pylint...................................................................Passed
pydocstyle...............................................................Passed
flake8...................................................................Passed
```

Runtime unit tests and GPU dry-run validation are not included in this model-only branch and should be tracked in the corresponding test/integration change.

### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

Generated-by: <tool name and version>
-->

Yes — portions were co-authored with an AI coding assistant.

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Added NVPanoptix3Dv2 model support for open-vocabulary panoptic segmentation and reasoning-guided 3D segmentation.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [x] All tests pass locally
- [ ] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->

Suggested review order:

1. `model/build_pl_model.py` for variant selection and lazy imports.
2. `model/vggt/` and `model/metric_scale_head.py` for shared geometry.
3. `model/panoptic/` for feature fusion, upscaling, mask decoding, and Lightning integration.
4. `model/reasoning/` for Qwen, SAM3, VGGT, and Lightning integration.

The implementation intentionally imports compatible layers and heads from the existing NVPanoptix3D and Mask2Former modules instead of maintaining local copies. The V2-specific VGGT aggregator remains local because it additionally returns raw DINO and final VGGT patch features required by the panoptic decoder.