### PR TITLE
[TAOVN-1251][Feature] Add NVPanoptix3Dv2 scripts, utilities, and experiment specs

### DIFF
--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 module.
+
+Feed-forward joint 3D reconstruction and open-vocabulary panoptic
+segmentation from unposed multi-view images.
+"""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/entrypoint/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/entrypoint/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Entrypoint script for the NVPanoptix3Dv2 task."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/entrypoint/nvpanoptix3d_v2.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/entrypoint/nvpanoptix3d_v2.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Define entrypoint to run tasks for NVPanoptix3Dv2 model."""
+
+import argparse
+
+from nvidia_tao_pytorch.core.entrypoint import get_subtasks, launch, command_line_parser
+import nvidia_tao_pytorch.cv.nvpanoptix3d_v2.scripts as scripts
+
+
+def get_subtask_list():
+    """Return the list of subtasks by inspecting the scripts package."""
+    return get_subtasks(scripts)
+
+
+def main():
+    """Main entrypoint wrapper."""
+    # Create parser for a given task.
+    parser = argparse.ArgumentParser(
+        "nvpanoptix3d_v2", add_help=True,
+        description="Train Adapt Optimize entrypoint for NVPanoptix3Dv2 model",
+    )
+
+    # Build list of subtasks by inspecting the package.
+    subtasks = get_subtask_list()
+
+    # Parse the arguments
+    args, unknown_args = command_line_parser(parser, subtasks)
+
+    # Launch the subtask.
+    launch(vars(args), unknown_args, subtasks, network="nvpanoptix3d_v2")
+
+
+if __name__ == "__main__":
+    main()

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/experiment_specs/spec_panoptic.yaml
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/experiment_specs/spec_panoptic.yaml
@@ -1,0 +1,124 @@
+results_dir: /results/nvpanoptix3d_v2_panoptic
+model:
+  model_type: panoptic
+  img_size: 518
+  patch_size: 14
+  embed_dim: 1024
+  backbone:
+    pretrained_backbone_path: ""
+    metric_depth_head:
+      enable: true
+      feat_dim: 2048
+      hidden_dims: [256, 64]
+      metric_context_views: 5
+  panoptic:
+    feature_fusion:
+      dino_dim: 1024
+      vggt_dim: 2048
+      hidden_dim: 768
+      num_heads: 12
+      num_layers: 3
+      ff_dim_mult: 4
+    panoptic_decoder:
+      hidden_dim: 768
+      mask_dim: 384
+      ff_dim: 2048
+      num_queries: 200
+      num_heads: 8
+      dec_layers: 6
+      fixed_vocab: true
+      label_mode: sigmoid
+      deep_supervision: true
+      enable_objectness: true
+    upscaler:
+      input_dim: 768
+      dim: 384
+      output_stride: 2
+      patch_size: 14
+      color_feats: true
+      n_freqs: 20
+      num_heads: 4
+      num_layers: 2
+train:
+  num_gpus: 8
+  gpu_ids: [0, 1, 2, 3, 4, 5, 6, 7]
+  num_nodes: 1
+  seed: 42
+  num_epochs: 50
+  val_check_interval: 1.0
+  accum_iter: 1
+  lr: 1.0e-4
+  min_lr: 1.0e-6
+  weight_decay: 0.05
+  warmup_epochs: 2
+  precision: fp32
+  is_dry_run: false
+  checkpointer:
+    enable_topk: true
+    monitor: val/mAP
+    save_top_k: 2
+  pretrained_model_path: null
+  cudnn:
+    benchmark: true
+    deterministic: false
+  metric_depth:
+    weight: 5.0
+    silog_weight: 1.0
+    absrel_weight: 0.1
+    silog_lambda: 0.85
+    min_depth: 0.1
+    max_depth: 30.0
+  panoptic:
+    class_weight: 2.0
+    rank_weight: 0.5
+    objectness_weight: 1.0
+    objectness_no_object_weight: 0.1
+    objectness_ignore_overlap_threshold: 0.5
+    mask_weight: 20.0
+    dice_weight: 1.0
+    num_loss_points: 12288
+dataset:
+  panoptic:
+    train_preprocessed_root: /workspace/nvpanoptix3d_v2/data/pre_scannetpp_v2
+    val_preprocessed_root: /workspace/nvpanoptix3d_v2/data/pre_scannetpp_v2_val
+    photometric_augmentation:
+      enabled: true
+      color_jitter_prob: 0.8
+      brightness: 0.10
+      contrast: 0.10
+      saturation: 0.15
+      gamma_exposure_prob: 0.5
+      gamma: 0.10
+      exposure_ev: 0.15
+      grayscale_prob: 0.05
+    num_views: 5
+    randomize_view_order: true
+    pairs_per_scene: 50
+    batch_size: 1
+    resolution:
+      - [518, 518]
+      - [518, 378]
+      - [518, 322]
+evaluate:
+  checkpoint: /results/nvpanoptix3d_v2/train/nvpanoptix3d_v2_panoptic_model_latest.pth
+  num_gpus: 1
+  gpu_ids: [0]
+  cls_threshold: 0.1
+  mask_threshold: 0.25
+  overlap_threshold: 0.5
+inference:
+  checkpoint: /results/nvpanoptix3d_v2/train/nvpanoptix3d_v2_panoptic_model_latest.pth
+  num_gpus: 1
+  gpu_ids: [0]
+  output_dir: null
+  cls_threshold: 0.1
+  mask_threshold: 0.25
+  overlap_threshold: 0.5
+  categories_json: null
+export:
+  checkpoint: /results/nvpanoptix3d_v2/train/nvpanoptix3d_v2_panoptic_model_latest.pth
+  onnx_file: ""
+  categories_json: null
+  input_width: 518
+  input_height: 518
+  num_views: 5

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/experiment_specs/spec_reasoning.yaml
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/experiment_specs/spec_reasoning.yaml
@@ -1,0 +1,88 @@
+results_dir: /results/nvpanoptix3d_v2_reasoning
+model:
+  model_type: reasoning
+  img_size: 518
+  patch_size: 14
+  embed_dim: 1024
+  backbone:
+    pretrained_backbone_path: ""
+    metric_depth_head:
+      enable: true
+      feat_dim: 2048
+      hidden_dims: [256, 64]
+      metric_context_views: 5
+  reasoning:
+    qwen:
+      model_id: Qwen/Qwen3-VL-4B-Instruct
+      seg_token: "[SEG]"
+      freeze_vision: true
+      dtype: bfloat16
+      attn_implementation: sdpa
+      use_lora: true
+      lora:
+        r: 16
+        alpha: 32
+        dropout: 0.05
+    sam3:
+      load_from_hf: true
+      resolution: 1008
+    sam_bridge:
+      sam_prompt_dim: 256
+      hidden_dim: 4096
+      dropout: 0.0
+    point_mask_threshold: 0.5
+    point_conf_threshold: null
+train:
+  num_gpus: 1
+  gpu_ids: [0]
+  num_nodes: 1
+  seed: 42
+  num_epochs: 3
+  val_check_interval: 1.0
+  accum_iter: 1
+  lr: 2.0e-4
+  min_lr: 1.0e-6
+  weight_decay: 0.0
+  warmup_epochs: 2
+  precision: bf16
+  is_dry_run: false
+  clip_grad_norm: 1.0
+  checkpointer:
+    enable_topk: true
+    monitor: val/mIoU
+    save_top_k: 2
+  pretrained_model_path: null
+  cudnn:
+    benchmark: true
+    deterministic: false
+  metric_depth:
+    weight: 0.1
+    silog_weight: 1.0
+    absrel_weight: 0.1
+    silog_lambda: 0.85
+    min_depth: 0.1
+    max_depth: 30.0
+  reasoning:
+    text_weight: 1.0
+    mask_weight: 20.0
+    dice_weight: 1.0
+    score_weight: 1.0
+dataset:
+  reasoning:
+    train_manifest: /workspace/nvpanoptix3d_v2/reasoning_data/scannetpp_reason_train.jsonl
+    val_manifest: /workspace/nvpanoptix3d_v2/reasoning_data/scannetpp_reason_val.jsonl
+    require_seg_token: true
+    resolution: [518, 518]
+    num_views: 5
+    batch_size: 1
+evaluate:
+  checkpoint: /results/nvpanoptix3d_v2_reasoning/train/nvpanoptix3d_v2_reasoning_model_latest.pth
+  num_gpus: 1
+  gpu_ids: [0]
+  mask_threshold: 0.5
+inference:
+  checkpoint: /results/nvpanoptix3d_v2_reasoning/train/nvpanoptix3d_v2_reasoning_model_latest.pth
+  num_gpus: 1
+  gpu_ids: [0]
+  output_dir: null
+  mask_threshold: 0.5

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 scripts."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/evaluate.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/evaluate.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 evaluation script.
+
+Variant-agnostic: the panoptic variant reports mAP/mAP50/mAP25, while the
+reasoning variant reports mIoU/mAP50/mAP25 on canonical point clouds.
+"""
+
+import os
+
+from pytorch_lightning import Trainer
+
+from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
+from nvidia_tao_pytorch.core.initialize_experiments import initialize_evaluation_experiment
+
+from nvidia_tao_pytorch.config.nvpanoptix3d_v2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader import build_pl_data_module
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.build_pl_model import PANOPTIC, load_pl_model
+
+
+def run_experiment(experiment_config):
+    """Start the evaluation."""
+    model_path, trainer_kwargs = initialize_evaluation_experiment(experiment_config)
+
+    pl_data = build_pl_data_module(experiment_config)
+    pl_model = load_pl_model(experiment_config, model_path, strict=False)
+
+    if str(experiment_config.model.model_type) == PANOPTIC:
+        from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.pl_data_module import (
+            resolve_vocabulary,
+        )
+        # Category metadata selects the ``isthing`` subset used by instance AP.
+        pl_model.set_classes(**resolve_vocabulary(experiment_config.dataset.panoptic))
+
+    trainer_kwargs["use_distributed_sampler"] = False
+    trainer_kwargs["enable_checkpointing"] = False
+    trainer = Trainer(**trainer_kwargs)
+    trainer.test(pl_model, datamodule=pl_data)
+
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@hydra_runner(
+    config_path=os.path.join(spec_root, "experiment_specs"),
+    config_name="spec_panoptic", schema=ExperimentConfig
+)
+@monitor_status(name="NVPanoptix3Dv2", mode="evaluate")
+def main(cfg: ExperimentConfig) -> None:
+    """Run the evaluation process."""
+    run_experiment(experiment_config=cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/export.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/export.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export the NVPanoptix3Dv2 panoptic model to ONNX.
+
+Only the panoptic variant is exportable; the reasoning variant decodes text
+autoregressively and needs an LLM serving stack, not a single graph.
+
+The vocabulary is baked into the graph, so it is resolved here from
+``export.categories_json`` when set -- preferred, since it needs no dataset
+-- and otherwise from the dataset taxonomy, which requires the preprocessed
+roots in ``dataset.panoptic`` to be readable.
+"""
+
+import json
+import os
+
+import torch
+
+from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
+from nvidia_tao_pytorch.core.tlt_logging import logging
+
+from nvidia_tao_pytorch.config.nvpanoptix3d_v2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.build_pl_model import PANOPTIC, load_pl_model
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.export.onnx_exporter import (
+    INPUT_NAME,
+    NVPanoptix3Dv2PanopticExportWrapper,
+    ONNXExporter,
+    encode_vocabulary,
+    export_safe_metric_scale_head,
+    write_vocabulary_sidecar,
+)
+
+
+def resolve_export_vocabulary(experiment_config):
+    """Resolve the class vocabulary to bake into the exported graph.
+
+    Args:
+        experiment_config: The experiment config.
+
+    Returns:
+        Tuple of (classes, categories). ``categories`` is None when the source
+        carries no category metadata.
+    """
+    categories_json = experiment_config.export.categories_json
+    if categories_json:
+        with open(categories_json, "r", encoding="utf-8") as handle:
+            categories = json.load(handle)
+        classes = [category["name"] for category in categories]
+        logging.info(f"Exporting against {len(classes)} classes from {categories_json}")
+        return classes, categories
+
+    from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.pl_data_module import (
+        resolve_vocabulary,
+    )
+    vocabulary = resolve_vocabulary(experiment_config.dataset.panoptic)
+
+    classes = list(vocabulary["classes"])
+    categories = vocabulary.get("categories")
+    logging.info(f"Exporting against {len(classes)} classes from the dataset taxonomy")
+    return classes, categories
+
+
+def run_export(experiment_config):
+    """Export the panoptic model to ONNX.
+
+    Args:
+        experiment_config: The experiment config.
+
+    Returns:
+        No explicit returns.
+    """
+    model_type = str(experiment_config.model.model_type)
+    if model_type != PANOPTIC:
+        raise ValueError(
+            f"ONNX export supports model.model_type='{PANOPTIC}' only, got '{model_type}'. "
+            "The reasoning variant decodes text autoregressively and is not a "
+            "single feed-forward graph."
+        )
+
+    export_config = experiment_config.export
+    on_cpu = export_config.on_cpu
+    if not on_cpu:
+        torch.cuda.set_device(export_config.gpu_id)
+    device = torch.device("cpu" if on_cpu else "cuda")
+
+    model_path = export_config.checkpoint
+    if not model_path:
+        raise ValueError("export.checkpoint must point at the checkpoint to export.")
+    input_height = export_config.input_height
+    input_width = export_config.input_width
+    num_views = export_config.num_views
+    opset_version = export_config.opset_version
+    batch_size = export_config.batch_size
+    traced_batch_size = 1 if batch_size in (None, -1) else batch_size
+
+    patch_size = experiment_config.model.patch_size
+    if input_height % patch_size or input_width % patch_size:
+        raise ValueError(
+            f"export.input_height/input_width ({input_height}x{input_width}) must both be "
+            f"divisible by model.patch_size={patch_size}."
+        )
+
+    output_file = export_config.onnx_file
+    if not output_file:
+        output_file = f"{os.path.splitext(model_path)[0]}.onnx"
+    # Never silently overwrite: the weights land in external-data files beside
+    # the graph, so a partial overwrite leaves an unloadable pair behind.
+    if os.path.exists(output_file):
+        raise FileExistsError(f"ONNX file {output_file} already exists; remove it or set export.onnx_file")
+    os.makedirs(os.path.dirname(os.path.realpath(output_file)), exist_ok=True)
+
+    classes, categories = resolve_export_vocabulary(experiment_config)
+
+    pl_model = load_pl_model(experiment_config, model_path, strict=False)
+    pl_model.to(device)
+    pl_model.eval()
+
+    # Encode the vocabulary before wrapping: this is the last point at which
+    # the real SigLIP text encoder is still attached.
+    class_embeddings = encode_vocabulary(pl_model, classes, categories)
+
+    dummy_input = torch.rand(
+        traced_batch_size, num_views, 3, input_height, input_width, device=device,
+    )
+
+    with export_safe_metric_scale_head():
+        # Constructing the wrapper freezes the text encoder and then probes the
+        # model once to learn which outputs this build actually produces.
+        wrapper = NVPanoptix3Dv2PanopticExportWrapper(
+            pl_model.model.eval(),
+            class_embeddings.to(device),
+            probe_input=dummy_input,
+        ).to(device).eval()
+
+        logging.info(
+            "Tracing %s with input [%d, %d, 3, %d, %d] -> outputs: %s",
+            INPUT_NAME, traced_batch_size, num_views, input_height, input_width,
+            ", ".join(wrapper.output_names),
+        )
+
+        exporter = ONNXExporter(opset_version=opset_version)
+        exporter.export_model(
+            wrapper,
+            output_file,
+            dummy_input,
+            input_names=[INPUT_NAME],
+            output_names=wrapper.output_names,
+            batch_size=batch_size,
+            verbose=export_config.verbose,
+        )
+
+    exporter.check_onnx(output_file)
+    sidecar = write_vocabulary_sidecar(output_file, classes, categories)
+
+    if batch_size in (None, -1):
+        logging.info("Exported with a dynamic batch axis; the %d-view axis is static.", num_views)
+    else:
+        logging.info("Exported with static shapes (batch=%d, views=%d).", batch_size, num_views)
+    logging.info("ONNX file stored at %s", output_file)
+    logging.info("Class vocabulary stored at %s", sidecar)
+
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@hydra_runner(
+    config_path=os.path.join(spec_root, "experiment_specs"),
+    config_name="spec_panoptic", schema=ExperimentConfig
+)
+@monitor_status(name="NVPanoptix3Dv2", mode="export")
+def main(cfg: ExperimentConfig) -> None:
+    """Run the export process."""
+    torch.backends.cudnn.allow_tf32 = False
+    torch.backends.cuda.matmul.allow_tf32 = False
+    run_export(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/inference.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/inference.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 inference script.
+
+Variant-agnostic: the panoptic variant writes per-sample panoptic maps, the
+reasoning variant writes per-``[SEG]`` masks and fused point clouds.
+"""
+
+import json
+import os
+
+from pytorch_lightning import Trainer
+
+from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
+from nvidia_tao_pytorch.core.initialize_experiments import initialize_inference_experiment
+from nvidia_tao_pytorch.core.tlt_logging import logging
+
+from nvidia_tao_pytorch.config.nvpanoptix3d_v2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader import build_pl_data_module
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.build_pl_model import PANOPTIC, load_pl_model
+
+
+def run_experiment(experiment_config):
+    """Start the inference."""
+    model_path, trainer_kwargs = initialize_inference_experiment(experiment_config)
+
+    pl_data = build_pl_data_module(experiment_config)
+    pl_model = load_pl_model(experiment_config, model_path, strict=False)
+
+    if str(experiment_config.model.model_type) == PANOPTIC:
+        from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.pl_data_module import (
+            resolve_vocabulary,
+        )
+        vocabulary = resolve_vocabulary(experiment_config.dataset.panoptic)
+
+        # An explicit categories JSON replaces the dataset taxonomy for both the
+        # text prompts and the category IDs the predicted segments index into.
+        categories_json = experiment_config.inference.categories_json
+        if categories_json:
+            with open(categories_json, "r", encoding="utf-8") as handle:
+                categories = json.load(handle)
+            classes = [category["name"] for category in categories]
+            vocabulary.update(classes=classes, categories=categories)
+            logging.info(f"Predicting against {len(classes)} classes from {categories_json}")
+        pl_model.set_classes(**vocabulary)
+
+    trainer_kwargs["use_distributed_sampler"] = False
+    trainer_kwargs["enable_checkpointing"] = False
+    trainer = Trainer(**trainer_kwargs)
+    trainer.predict(pl_model, pl_data, return_predictions=False)
+
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@hydra_runner(
+    config_path=os.path.join(spec_root, "experiment_specs"),
+    config_name="spec_panoptic", schema=ExperimentConfig
+)
+@monitor_status(name="NVPanoptix3Dv2", mode="inference")
+def main(cfg: ExperimentConfig) -> None:
+    """Run the inference process."""
+    run_experiment(experiment_config=cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/train.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/scripts/train.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 training script.
+
+Variant-agnostic: ``model.model_type`` selects which Lightning module and data
+module are built. The panoptic module reports validation mAP, mAP50, and mAP25
+and uses ``val/mAP`` for optional metric-ranked checkpoints. The reasoning
+module reports canonical point-cloud mIoU, mAP50, and mAP25 and ranks its
+checkpoints on ``val/mIoU``.
+"""
+
+import os
+
+from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import LearningRateMonitor
+from pytorch_lightning.strategies import DDPStrategy
+
+from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
+from nvidia_tao_pytorch.core.initialize_experiments import initialize_train_experiment
+from nvidia_tao_pytorch.core.tlt_logging import logging
+
+from nvidia_tao_pytorch.config.nvpanoptix3d_v2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader import build_pl_data_module
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.build_pl_model import PANOPTIC, build_pl_model
+
+PRECISION_MAP = {
+    "fp32": "32-true",
+    "bf16": "bf16-mixed",
+    "fp16": "16-mixed",
+}
+
+
+def run_experiment(experiment_config):
+    """Start the training."""
+    model_type = str(experiment_config.model.model_type)
+    resume_ckpt, trainer_kwargs = initialize_train_experiment(experiment_config)
+
+    precision = PRECISION_MAP.get(str(experiment_config.train.precision).lower())
+    if precision is None:
+        raise NotImplementedError(
+            f"{experiment_config.train.precision} is not supported. "
+            f"Supported precisions: {', '.join(sorted(PRECISION_MAP))}"
+        )
+
+    # Build the data module first, then load the native ScanNet++ taxonomy before
+    # the panoptic model's first forward pass.
+    pl_data = build_pl_data_module(experiment_config)
+    pl_model = build_pl_model(experiment_config)
+
+    if model_type == PANOPTIC:
+        from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.pl_data_module import (
+            resolve_vocabulary,
+        )
+        # Category metadata selects the ``isthing`` subset used by instance AP.
+        pl_model.set_classes(**resolve_vocabulary(experiment_config.dataset.panoptic))
+
+    strategy = "auto"
+    if len(trainer_kwargs["devices"]) > 1 or experiment_config.train.num_nodes > 1:
+        # Both variants leave frozen branches without gradients: VGGT for the
+        # panoptic variant, plus the SAM3 and Qwen base weights for reasoning.
+        strategy = DDPStrategy(find_unused_parameters=True)
+
+    # The panoptic data module builds its own DistributedSampler and forwards the
+    # epoch to it from ``on_train_epoch_start``; the reasoning data module lets
+    # Lightning inject one.
+    trainer_kwargs["use_distributed_sampler"] = model_type != PANOPTIC
+
+    trainer = Trainer(
+        **trainer_kwargs,
+        num_nodes=experiment_config.train.num_nodes,
+        strategy=strategy,
+        precision=precision,
+        accumulate_grad_batches=experiment_config.train.accum_iter,
+        gradient_clip_val=experiment_config.train.clip_grad_norm,
+        val_check_interval=experiment_config.train.val_check_interval,
+        log_every_n_steps=experiment_config.train.log_interval,
+        num_sanity_val_steps=0,
+        fast_dev_run=experiment_config.train.is_dry_run,
+        limit_val_batches=0 if pl_data.val_dataloader() is None else 1.0,
+    )
+    trainer.callbacks.append(LearningRateMonitor(logging_interval="step"))
+
+    if resume_ckpt:
+        logging.info(f"Resuming training from {resume_ckpt}")
+    trainer.fit(pl_model, pl_data, ckpt_path=resume_ckpt)
+
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@hydra_runner(
+    config_path=os.path.join(spec_root, "experiment_specs"),
+    config_name="spec_panoptic", schema=ExperimentConfig
+)
+@monitor_status(name="NVPanoptix3Dv2", mode="train")
+def main(cfg: ExperimentConfig) -> None:
+    """Run the training process."""
+    run_experiment(experiment_config=cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 utilities shared across both variants."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/metric_depth.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/metric_depth.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Metric-depth supervision for the shared VGGT metric scale head."""
+
+from typing import Dict
+
+import torch
+import torch.nn as nn
+
+
+class MetricDepthLoss(nn.Module):
+    """SILog (+ optional AbsRel) supervision for the metric scale head.
+
+    The scale-invariant log (SILog) loss is the standard objective for
+    monocular metric depth regression (NYU / KITTI):
+
+        L_SILog =  (1/N) Σ (log d_pred − log d_gt)^2
+                 − (λ / N^2) (Σ (log d_pred − log d_gt))^2
+
+    with ``λ = 0.85``.  An optional AbsRel term
+
+        L_AbsRel = mean( |d_pred − d_gt| / d_gt )
+
+    can be added for direct metric accuracy supervision.
+
+    Args:
+        silog_weight:  Coefficient on the SILog term.
+        absrel_weight: Coefficient on the auxiliary AbsRel term (set to 0
+            to disable).
+        silog_lambda:  ``λ`` mixing constant (0..1) inside SILog.
+        min_depth:     Lower bound for valid GT depth (metres).
+        max_depth:     Upper bound for valid GT depth (metres).
+        min_pred:      Lower clamp on the prediction before taking ``log``.
+        eps:           Numerical safety added inside ``log``.
+    """
+
+    def __init__(
+        self,
+        silog_weight: float = 1.0,
+        absrel_weight: float = 0.1,
+        silog_lambda: float = 0.85,
+        min_depth: float = 0.1,
+        max_depth: float = 10.0,
+        min_pred: float = 1e-3,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.silog_weight = silog_weight
+        self.absrel_weight = absrel_weight
+        self.silog_lambda = silog_lambda
+        self.min_depth = min_depth
+        self.max_depth = max_depth
+        self.min_pred = min_pred
+        self.eps = eps
+
+    def forward(
+        self,
+        metric_depth: torch.Tensor,
+        gt_depth: torch.Tensor,
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Args:
+            metric_depth:       ``[B, S,H,W,1]`` scaled metric depth
+                ``s · d_rel``.
+            gt_depth:           ``[B, S, H, W]`` GT metric depth in metres.
+        Returns:
+            Dict with ``loss_silog``, ``loss_absrel`` and the aggregated
+            ``loss_metric_total``.  Per-batch elements with too few valid
+            pixels contribute zero (and don't contaminate the average).
+        """
+        if metric_depth.dim() == 5:
+            pred = metric_depth.squeeze(-1)  # [B, S, H, W]
+        else:
+            pred = metric_depth
+
+        gt = gt_depth
+
+        valid = (
+            torch.isfinite(gt) &
+            (gt > self.min_depth) &
+            (gt < self.max_depth) &
+            torch.isfinite(pred) &
+            (pred > self.min_pred)
+        )
+
+        device = pred.device
+        zero = torch.zeros((), device=device, dtype=pred.dtype)
+
+        B = pred.shape[0]
+        silog_terms = []
+        absrel_terms = []
+
+        for b in range(B):
+            m = valid[b]
+            n = int(m.sum().item())
+            if n < 10:
+                silog_terms.append(zero)
+                absrel_terms.append(zero)
+                continue
+
+            p = pred[b][m].clamp(min=self.min_pred)
+            g = gt[b][m].clamp(min=self.eps)
+
+            log_diff = torch.log(p + self.eps) - torch.log(g + self.eps)
+            silog = log_diff.pow(2).mean() - self.silog_lambda * log_diff.mean().pow(2)
+            silog_terms.append(silog)
+
+            if self.absrel_weight > 0:
+                absrel_terms.append(((p - g).abs() / g).mean())
+            else:
+                absrel_terms.append(zero)
+
+        loss_silog = torch.stack(silog_terms).mean()
+        loss_absrel = torch.stack(absrel_terms).mean()
+
+        loss_total = (
+            self.silog_weight * loss_silog +
+            self.absrel_weight * loss_absrel
+        )
+
+        return {
+            "loss_silog": loss_silog,
+            "loss_absrel": loss_absrel,
+            "loss_metric_total": loss_total,
+        }

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Losses, matcher, and instance-mAP evaluation for the panoptic variant."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/criterion.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/criterion.py
@@ -1,0 +1,485 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Modified from Mask2Former (https://github.com/facebookresearch/Mask2Former) for multi-view outputs
+
+"""Mask-transformer set criterion for panoptic segmentation."""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from nvidia_tao_pytorch.core.distributed.comm import (
+    get_world_size,
+    is_dist_avail_and_initialized,
+)
+from nvidia_tao_pytorch.cv.mask2former.utils.criterion import calculate_uncertainty
+from nvidia_tao_pytorch.cv.mask2former.utils.point_features import (
+    get_uncertain_point_coords_with_randomness,
+    point_sample,
+)
+
+
+def masked_dice_loss(
+    inputs: torch.Tensor,
+    targets: torch.Tensor,
+    valid: torch.Tensor,
+    num_masks: float,
+):
+    """Per-view Dice loss with void/ignored sample points at zero weight."""
+    if inputs.dim() == 2:
+        inputs = inputs.unsqueeze(1)
+        targets = targets.unsqueeze(1)
+        valid = valid.unsqueeze(1)
+    inputs = inputs.sigmoid()
+    valid = valid.to(dtype=inputs.dtype)
+    inputs = inputs * valid
+    targets = targets * valid
+    numerator = 2 * (inputs * targets).sum(-1)
+    denominator = inputs.sum(-1) + targets.sum(-1)
+    loss = 1 - (numerator + 1) / (denominator + 1)
+    valid_views = (valid.sum(-1) > 0).to(dtype=loss.dtype)
+    per_mask = (loss * valid_views).sum(-1) / valid_views.sum(-1).clamp_min(1.0)
+    return per_mask.sum() / num_masks
+
+
+masked_dice_loss_jit = torch.jit.script(masked_dice_loss)
+
+
+def masked_sigmoid_ce_loss(
+    inputs: torch.Tensor,
+    targets: torch.Tensor,
+    valid: torch.Tensor,
+    num_masks: float,
+):
+    """Per-view BCE normalised only over valid panoptic sample points."""
+    if inputs.dim() == 2:
+        inputs = inputs.unsqueeze(1)
+        targets = targets.unsqueeze(1)
+        valid = valid.unsqueeze(1)
+    valid = valid.to(dtype=inputs.dtype)
+    loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction="none")
+    valid_counts = valid.sum(-1)
+    per_view = (loss * valid).sum(-1) / valid_counts.clamp_min(1.0)
+    valid_views = (valid_counts > 0).to(dtype=per_view.dtype)
+    per_mask = (
+        (per_view * valid_views).sum(-1) /
+        valid_views.sum(-1).clamp_min(1.0)
+    )
+    return per_mask.sum() / num_masks
+
+
+masked_sigmoid_ce_loss_jit = torch.jit.script(masked_sigmoid_ce_loss)
+
+
+def sigmoid_focal_loss(
+    inputs, targets, num_masks, output_mask, alpha: float = 0.25, gamma: float = 2
+):
+    """Focal loss for the open-vocabulary classification head.
+
+    ``output_mask`` zeroes the vocabulary columns a batch's source taxonomy
+    does not cover, so union classes absent from that root never become
+    false negatives.
+    """
+    prob = inputs.sigmoid()
+    ce_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction="none")
+    p_t = prob * targets + (1 - prob) * (1 - targets)
+    loss = ce_loss * ((1 - p_t) ** gamma)
+
+    if alpha >= 0:
+        alpha_t = alpha * targets + (1 - alpha) * (1 - targets)
+        loss = alpha_t * loss
+
+    loss = loss * output_mask
+    return loss.mean(1).sum() / num_masks
+
+
+class SetCriterion(nn.Module):
+    """DETR-style set prediction loss with Hungarian matching.
+
+    Steps:
+      1. Hungarian assignment between GT and predictions
+      2. Supervise each matched pair (classification + mask)
+    """
+
+    def __init__(
+        self,
+        matcher,
+        weight_dict,
+        eos_coef,
+        losses,
+        num_points,
+        label_mode="softmax",
+        objectness_no_object_weight=0.1,
+        objectness_ignore_overlap_threshold=0.5,
+        oversample_ratio=3.0,
+        importance_sample_ratio=0.75,
+        aux_losses=None,
+    ):
+        super().__init__()
+        self.matcher = matcher
+        self.weight_dict = weight_dict
+        self.eos_coef = eos_coef
+        self.losses = list(losses)
+        # Rank and objectness are final-query decisions, so callers can limit
+        # auxiliary supervision to labels and masks.
+        self.aux_losses = (
+            list(aux_losses) if aux_losses is not None else list(losses)
+        )
+        self.num_points = num_points
+        self.oversample_ratio = oversample_ratio
+        self.importance_sample_ratio = importance_sample_ratio
+        self.label_mode = label_mode
+        self.objectness_no_object_weight = float(objectness_no_object_weight)
+        self.objectness_ignore_overlap_threshold = float(
+            objectness_ignore_overlap_threshold
+        )
+        if not 0.0 <= self.objectness_ignore_overlap_threshold <= 1.0:
+            raise ValueError(
+                "objectness_ignore_overlap_threshold must be in [0, 1]"
+            )
+
+    # classification losses
+
+    def loss_labels_sigmoid(self, outputs, targets, indices, num_masks):
+        """Classification loss for the multi-label sigmoid head."""
+        if "pred_logits" not in outputs:
+            raise ValueError("Classification loss requires pred_logits")
+        src_logits = outputs["pred_logits"].float()
+        num_classes = src_logits.shape[-1]
+        idx = self.get_src_permutation_idx(indices)
+        target_classes_o = torch.cat([t["labels"][J] for t, (_, J) in zip(targets, indices)])
+        target_classes = torch.full(
+            src_logits.shape[:2], num_classes, dtype=torch.int64, device=src_logits.device
+        )
+        target_classes[idx] = target_classes_o
+
+        output_mask = torch.stack([t["output_mask"] for t in targets]).unsqueeze(1)
+
+        # Vocabulary masking operates per class. Extend it per query so
+        # unmatched predictions dominated by ignored pixels receive no
+        # all-negative semantic target. Matched queries must always retain
+        # their positive and negative class supervision, even if their current
+        # predicted mask also overlaps an ignored region.
+        class_supervision_mask = output_mask.expand(
+            -1, src_logits.shape[1], -1,
+        )
+        ignored_queries = self.queries_on_ignored_regions(outputs, targets)
+        if ignored_queries is not None:
+            matched_queries = torch.zeros_like(ignored_queries)
+            matched_queries[idx] = True
+            ignored_unmatched = ignored_queries & ~matched_queries
+            class_supervision_mask = (
+                class_supervision_mask & ~ignored_unmatched.unsqueeze(-1)
+            )
+
+        target_classes_oh = torch.zeros(
+            [src_logits.shape[0], src_logits.shape[1], src_logits.shape[2] + 1],
+            dtype=src_logits.dtype, layout=src_logits.layout, device=src_logits.device,
+        )
+        target_classes_oh.scatter_(2, target_classes.unsqueeze(-1), 1)
+        target_classes_oh = target_classes_oh[:, :, :-1]
+
+        # sigmoid_focal_loss sums over eligible ScanNet++ class columns.
+        # Normalize by the number of active columns.
+        vocab_ref = 100.0
+        active_classes = output_mask.sum(dim=-1).float().mean().clamp_min(1.0)
+        loss_focal = (
+            sigmoid_focal_loss(
+                src_logits, target_classes_oh, num_masks,
+                class_supervision_mask,
+            ) *
+            src_logits.shape[1] *
+            (vocab_ref / active_classes)
+        )
+        return {"loss_ce": loss_focal}
+
+    def loss_labels_softmax(self, outputs, targets, indices, num_masks):
+        """Classification loss for the single-label softmax head."""
+        del num_masks
+        if "pred_logits" not in outputs:
+            raise ValueError("Classification loss requires pred_logits")
+        src_logits = outputs["pred_logits"].float()
+        num_classes = src_logits.shape[-1] - 1
+        idx = self.get_src_permutation_idx(indices)
+        target_classes_o = torch.cat([t["labels"][J] for t, (_, J) in zip(targets, indices)])
+        target_classes = torch.full(
+            src_logits.shape[:2], num_classes, dtype=torch.int64, device=src_logits.device
+        )
+        target_classes[idx] = target_classes_o
+
+        output_mask = torch.stack([t["output_mask"] for t in targets]).unsqueeze(1)
+        output_mask = F.pad(output_mask, (0, 1), value=True)
+        src_logits_masked = torch.where(output_mask, src_logits, float("-inf"))
+
+        empty_weight = torch.ones(num_classes + 1, device=src_logits.device)
+        empty_weight[-1] = self.eos_coef
+
+        loss_ce = F.cross_entropy(
+            src_logits_masked.transpose(1, 2), target_classes, empty_weight
+        )
+        return {"loss_ce": loss_ce}
+
+    def loss_labels_rank(self, outputs, targets, indices, num_masks):
+        """Cross-entropy over classes for Hungarian-matched queries only.
+
+        Sigmoid focal loss teaches independent class compatibility, while
+        inference emits one winning class per query. This complementary loss
+        directly trains that top-1 decision and sharpens close semantic pairs
+        such as cushion/pillow and cabinet/kitchen-cabinet.
+        """
+        del num_masks
+        src_logits = outputs["pred_logits"].float()
+        src_idx = self.get_src_permutation_idx(indices)
+        if src_idx[0].numel() == 0:
+            return {"loss_rank": src_logits.sum() * 0.0}
+
+        matched_logits = src_logits[src_idx]
+        matched_targets = torch.cat([
+            target["labels"][tgt_idx]
+            for target, (_, tgt_idx) in zip(targets, indices)
+        ])
+        matched_column_masks = torch.cat([
+            target["output_mask"].unsqueeze(0).expand(src_idx_i.numel(), -1)
+            for target, (src_idx_i, _) in zip(targets, indices)
+        ], dim=0)
+        matched_logits = matched_logits.masked_fill(
+            ~matched_column_masks.to(matched_logits.device), -1.0e4,
+        )
+        return {
+            "loss_rank": F.cross_entropy(matched_logits, matched_targets)
+        }
+
+    def loss_objectness(self, outputs, targets, indices, _num_masks):
+        """Binary query supervision, excluding ignored-region detections.
+
+        Matched queries are always positive. An unmatched query whose
+        predicted foreground support lies primarily on ignored pixels
+        gets zero weight instead of a false no-object target.
+        """
+        logits = outputs.get("pred_objectness")
+        if logits is None:
+            raise ValueError(
+                "objectness loss requested but model returned no "
+                "pred_objectness logits"
+            )
+        logits = logits.float()
+        if logits.ndim == 3 and logits.shape[-1] == 1:
+            logits = logits.squeeze(-1)
+        if logits.ndim != 2:
+            raise ValueError(
+                f"pred_objectness must have shape [B,Q], got {logits.shape}"
+            )
+
+        target = torch.zeros_like(logits)
+        src_idx = self.get_src_permutation_idx(indices)
+        target[src_idx] = 1.0
+        raw = F.binary_cross_entropy_with_logits(logits, target, reduction="none")
+        neg_weight = self.objectness_no_object_weight
+        weights = target + (1.0 - target) * neg_weight
+
+        ignored_queries = self.queries_on_ignored_regions(outputs, targets)
+        if ignored_queries is not None:
+            weights = weights.masked_fill(
+                ignored_queries & (target == 0), 0.0,
+            )
+        loss = (raw * weights).sum() / weights.sum().clamp_min(1.0)
+        return {"loss_objectness": loss}
+
+    @torch.no_grad()
+    def queries_on_ignored_regions(self, outputs, targets):
+        """Return ``[B,Q]`` for masks dominated by ignored pixels."""
+        pred_masks = outputs.get("pred_masks")
+        if pred_masks is None or not targets:
+            return None
+        if pred_masks.ndim != 5:
+            raise ValueError(
+                "pred_masks must have shape [B,views,Q,H,W] for "
+                "ignore-aware objectness"
+            )
+
+        batch_size, num_views, num_queries, height, width = pred_masks.shape
+        if len(targets) != batch_size:
+            raise ValueError("targets and pred_masks batch size must match")
+
+        ignore_queries = torch.zeros(
+            batch_size, num_queries, dtype=torch.bool,
+            device=pred_masks.device,
+        )
+        for batch_index, target_dict in enumerate(targets):
+            ignored = target_dict["ignored_panoptic_mask"]
+            if not bool(ignored.any()):
+                continue
+            ignored = ignored.to(device=pred_masks.device, dtype=torch.float32)
+            if ignored.shape[0] != num_views:
+                raise ValueError(
+                    "ignored_panoptic_mask and pred_masks view counts must match"
+                )
+            ignored = F.interpolate(
+                ignored.unsqueeze(1), size=(height, width), mode="nearest",
+            ).squeeze(1).bool()
+
+            predicted_foreground = (
+                pred_masks[batch_index].transpose(0, 1).detach() > 0
+            )
+            support = predicted_foreground.sum(dim=(1, 2, 3))
+            overlap = (
+                predicted_foreground & ignored.unsqueeze(0)
+            ).sum(dim=(1, 2, 3))
+            fraction = overlap.float() / support.clamp_min(1).float()
+            ignore_queries[batch_index] = (
+                (support > 0) &
+                (fraction >= self.objectness_ignore_overlap_threshold)
+            )
+        return ignore_queries
+
+    # mask losses
+
+    def loss_masks(self, outputs, targets, indices, num_masks):
+        """Point-sampled mask and Dice losses for the Hungarian-matched queries."""
+        if "pred_masks" not in outputs:
+            raise ValueError("Mask loss requires pred_masks")
+
+        src_idx = self.get_src_permutation_idx(indices)
+        tgt_idx = self.get_tgt_permutation_idx(indices)
+
+        if src_idx[0].numel() == 0:
+            zero = outputs["pred_masks"].sum() * 0.0
+            return {"loss_mask": zero, "loss_dice": zero.clone()}
+
+        src_masks = outputs["pred_masks"]
+        src_masks = src_masks.transpose(1, 2)[src_idx]
+
+        masks = [t["masks"] for t in targets]
+        max_n = max(m.shape[0] for m in masks)
+        padded = []
+        for m in masks:
+            if m.shape[0] < max_n:
+                pad = m.new_zeros(max_n - m.shape[0], *m.shape[1:])
+                m = torch.cat([m, pad], dim=0)
+            padded.append(m)
+        target_masks = torch.stack(padded).to(src_masks)
+        target_masks = target_masks[tgt_idx]
+
+        valid_masks = torch.stack([
+            target["valid_panoptic_mask"] for target in targets
+        ]).to(
+            device=src_masks.device
+        )
+        valid_masks = valid_masks[src_idx[0]]
+
+        n, v = src_masks.shape[:2]
+        src_masks = src_masks.flatten(0, 1).unsqueeze(1)
+        target_masks = target_masks.flatten(0, 1).unsqueeze(1)
+        valid_masks = valid_masks.flatten(0, 1).unsqueeze(1)
+
+        with torch.no_grad():
+            point_coords = get_uncertain_point_coords_with_randomness(
+                src_masks,
+                lambda logits: calculate_uncertainty(logits),
+                self.num_points,
+                self.oversample_ratio,
+                self.importance_sample_ratio,
+            )
+            point_labels = point_sample(
+                target_masks, point_coords, align_corners=False
+            ).squeeze(1)
+            point_valid = point_sample(
+                valid_masks.float(), point_coords, mode="nearest",
+                align_corners=False,
+            ).squeeze(1)
+
+        point_logits = point_sample(
+            src_masks, point_coords, align_corners=False
+        ).squeeze(1)
+
+        point_logits = point_logits.unflatten(0, (n, v))
+        point_labels = point_labels.unflatten(0, (n, v))
+        point_valid = point_valid.unflatten(0, (n, v))
+
+        return {
+            "loss_mask": masked_sigmoid_ce_loss_jit(
+                point_logits, point_labels, point_valid, num_masks,
+            ),
+            "loss_dice": masked_dice_loss_jit(
+                point_logits, point_labels, point_valid, num_masks,
+            ),
+        }
+
+    # index helpers
+
+    def get_src_permutation_idx(self, indices):
+        """Return batch and source-query indices for matched predictions."""
+        batch_idx = torch.cat([torch.full_like(src, i) for i, (src, _) in enumerate(indices)])
+        src_idx = torch.cat([src for (src, _) in indices])
+        return batch_idx, src_idx
+
+    def get_tgt_permutation_idx(self, indices):
+        """Return batch and target indices for matched annotations."""
+        batch_idx = torch.cat([torch.full_like(tgt, i) for i, (_, tgt) in enumerate(indices)])
+        tgt_idx = torch.cat([tgt for (_, tgt) in indices])
+        return batch_idx, tgt_idx
+
+    def get_loss(self, loss, outputs, targets, indices, num_masks):
+        """Dispatch to the loss function registered under ``loss``."""
+        loss_map = {
+            "labels": self.loss_labels_softmax if self.label_mode == "softmax" else self.loss_labels_sigmoid,
+            "labels_rank": self.loss_labels_rank,
+            "objectness": self.loss_objectness,
+            "masks": self.loss_masks,
+        }
+        if loss not in loss_map:
+            raise ValueError(f"Unsupported loss: {loss}")
+        return loss_map[loss](outputs, targets, indices, num_masks)
+
+    # main forward
+
+    def forward(self, outputs, targets):
+        """Match predictions to targets and accumulate every configured loss term."""
+        outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}
+        final_indices = self.matcher(outputs_without_aux, targets)
+
+        num_masks = sum(len(t["labels"]) for t in targets)
+        num_masks = torch.as_tensor(
+            [num_masks], dtype=torch.float, device=next(iter(outputs.values())).device
+        )
+        if is_dist_avail_and_initialized():
+            torch.distributed.all_reduce(num_masks)
+        num_masks = torch.clamp(num_masks / get_world_size(), min=1).item()
+
+        losses = {}
+        for loss in self.losses:
+            losses.update(self.get_loss(loss, outputs, targets, final_indices, num_masks))
+
+        if "aux_outputs" in outputs:
+            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+                aux_indices = self.matcher(aux_outputs, targets)
+                for loss in self.aux_losses:
+                    l_dict = self.get_loss(loss, aux_outputs, targets, aux_indices, num_masks)
+                    l_dict = {k + f"_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+
+        return losses, final_indices
+
+    def __repr__(self):
+        """Render the configured loss terms and their weights."""
+        head = "Criterion " + self.__class__.__name__
+        body = [
+            "matcher: {}".format(self.matcher.__repr__(_repr_indent=8)),
+            "losses: {}".format(self.losses),
+            "aux_losses: {}".format(self.aux_losses),
+            "weight_dict: {}".format(self.weight_dict),
+            "eos_coef: {}".format(self.eos_coef),
+            "objectness_no_object_weight: {}".format(
+                self.objectness_no_object_weight
+            ),
+            "objectness_ignore_overlap_threshold: {}".format(
+                self.objectness_ignore_overlap_threshold
+            ),
+            "num_points: {}".format(self.num_points),
+            "oversample_ratio: {}".format(self.oversample_ratio),
+            "importance_sample_ratio: {}".format(self.importance_sample_ratio),
+        ]
+        _repr_indent = 4
+        lines = [head] + [" " * _repr_indent + line for line in body]
+        return "\n".join(lines)

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/engine_eval.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/engine_eval.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Panoptic post-processing for NVPanoptix3Dv2 model outputs."""
+
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+@torch.no_grad()
+def panoptic_inference(
+    mask_cls: torch.Tensor,
+    mask_pred: torch.Tensor,
+    target_hw: Tuple[int, int],
+    label_mode: str = "sigmoid",
+    cls_threshold: float = 0.1,
+    mask_threshold: float = 0.25,
+    overlap_threshold: float = 0.5,
+    presence_logits: Optional[torch.Tensor] = None,
+    objectness_logits: Optional[torch.Tensor] = None,
+) -> List[Dict]:
+    """Convert raw model logits into panoptic segmentation maps.
+
+    Args:
+        mask_cls:   [B, Q, C] class logits
+        mask_pred:  [B, S, Q, H_feat, W_feat] mask logits (pre-sigmoid)
+        target_hw:  (H, W) to resize masks to
+        label_mode: "sigmoid" or "softmax"
+        cls_threshold: minimum confidence to keep a query
+        mask_threshold: binarisation threshold for masks
+        overlap_threshold: minimum ratio of original mask area to keep
+        presence_logits: optional [B, C] from presence head — gates per-class scores
+        objectness_logits: optional [B, Q] matched/unmatched query logits
+
+    Returns:
+        list of B dicts, each containing:
+          - ``pan``:           [S, H, W] int32 panoptic segment IDs
+          - ``segments_info``: list of {id, category_id, score, area}
+    """
+    B, S, Q, _, _ = mask_pred.shape
+    H, W = target_hw
+
+    mask_pred = mask_pred.sigmoid()
+    mask_pred = mask_pred.reshape(B * S, Q, mask_pred.shape[-2], mask_pred.shape[-1])
+    mask_pred = F.interpolate(mask_pred, size=(H, W), mode="bilinear", align_corners=False)
+    mask_pred = mask_pred.reshape(B, S, Q, H, W)
+
+    presence_probs = None
+    if presence_logits is not None:
+        presence_probs = presence_logits.sigmoid()  # [B, C]
+    objectness_probs = None
+    if objectness_logits is not None:
+        objectness_probs = objectness_logits.sigmoid()  # [B, Q]
+
+    results = []
+    for bi in range(B):
+        cls_i = mask_cls[bi]
+        masks_i = mask_pred[bi]
+        masks_i = masks_i.transpose(0, 1)
+
+        if label_mode == "sigmoid":
+            query_probs = cls_i.sigmoid()             # [Q, C]
+            if presence_probs is not None:
+                query_probs = query_probs * presence_probs[bi].unsqueeze(0)
+            scores, labels = query_probs.max(-1)
+            if objectness_probs is not None:
+                scores = scores * objectness_probs[bi]
+            keep = scores > cls_threshold
+        else:
+            scores, labels = F.softmax(cls_i, dim=-1).max(-1)
+            if objectness_probs is not None:
+                scores = scores * objectness_probs[bi]
+            num_classes = cls_i.shape[-1] - 1
+            keep = labels.ne(num_classes) & (scores > cls_threshold)
+
+        cur_scores = scores[keep]
+        cur_classes = labels[keep]
+        cur_masks = masks_i[keep]
+
+        cur_prob_masks = cur_scores.view(-1, 1, 1, 1) * cur_masks
+
+        panoptic_seg = torch.zeros((S, H, W), dtype=torch.int32, device=masks_i.device)
+        segments_info = []
+
+        if cur_masks.shape[0] == 0:
+            results.append({"pan": panoptic_seg, "segments_info": segments_info})
+            continue
+
+        cur_mask_ids = cur_prob_masks.argmax(0)
+        current_segment_id = 0
+
+        for k in range(cur_classes.shape[0]):
+            pred_class = cur_classes[k].item()
+            original_area = (cur_masks[k] >= 0.5).sum().item()
+            mask = (cur_mask_ids == k) & (cur_masks[k] >= mask_threshold)
+            mask_area = mask.sum().item()
+
+            if mask_area > 0 and original_area > 0:
+                if mask_area / original_area < overlap_threshold:
+                    continue
+
+                current_segment_id += 1
+                panoptic_seg[mask] = current_segment_id
+                segments_info.append({
+                    "id": current_segment_id,
+                    "category_id": pred_class,
+                    "score": float(cur_scores[k].item()),
+                    "area": mask_area,
+                })
+
+        results.append({"pan": panoptic_seg, "segments_info": segments_info})
+
+    return results

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/losses.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/losses.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Losses for NVPanoptix3Dv2 panoptic training.
+
+Combined loss:
+  L = L_panoptic + λ_metric · L_metric_depth
+
+L_panoptic:
+  - Focal/sigmoid cross-entropy for classification
+  - Binary CE + Dice for mask prediction
+  - Deep supervision across all decoder layers
+
+L_metric_depth (MetricScaleHead supervision):
+  - SILog (scale-invariant log) loss between corrected metric depth and GT
+  - Optional AbsRel auxiliary term for direct metric accuracy
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.metric_depth import MetricDepthLoss
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.criterion import SetCriterion
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.matcher import HungarianMatcher
+
+# Broad catch-all names are excluded if a ScanNet++ taxonomy contains them.
+# Their text embeddings sit near many specific object names, so using them as
+# positives would inject conflicting gradients into the language projection.
+IGNORE_CLASS_NAMES = frozenset({
+    "other structure",
+    "other furniture",
+    "other prop",
+    "trinkets",
+})
+
+
+class NVPanoptix3Dv2PanopticLoss(nn.Module):
+    """
+    Combined loss for NVPanoptix3Dv2 training.
+
+    L = L_panoptic + λ_metric · L_metric_depth
+    """
+
+    def __init__(
+        self,
+        dec_layers: int = 6,
+        deep_supervision: bool = True,
+        class_weight: float = 1.0,
+        rank_weight: float = 0.0,
+        objectness_weight: float = 0.0,
+        objectness_no_object_weight: float = 0.1,
+        objectness_ignore_overlap_threshold: float = 0.5,
+        mask_weight: float = 20.0,
+        dice_weight: float = 1.0,
+        num_points: int = 2048,
+        label_mode: str = "sigmoid",
+        metric_depth_weight: float = 0.0,
+        metric_silog_weight: float = 1.0,
+        metric_absrel_weight: float = 0.1,
+        metric_silog_lambda: float = 0.85,
+        metric_min_depth: float = 0.1,
+        metric_max_depth: float = 10.0,
+    ):
+        super().__init__()
+        matcher = HungarianMatcher(
+            cost_class=class_weight,
+            cost_mask=mask_weight,
+            cost_dice=dice_weight,
+            num_points=num_points,
+            label_mode=label_mode,
+        )
+
+        panoptic_weight_dict = {
+            "loss_ce": class_weight,
+            "loss_mask": mask_weight,
+            "loss_dice": dice_weight,
+        }
+        weight_dict = dict(panoptic_weight_dict)
+        if rank_weight > 0:
+            weight_dict["loss_rank"] = float(rank_weight)
+        if objectness_weight > 0:
+            weight_dict["loss_objectness"] = float(objectness_weight)
+        if deep_supervision:
+            aux_weight_dict = {}
+            for i in range(dec_layers):
+                # Only the standard class/mask objectives receive deep
+                # supervision. Rank and objectness are final-query decisions;
+                # supervising them on independently re-matched intermediate
+                # layers destabilizes query identity and multiplies their
+                # effective weight by the number of decoder predictions.
+                aux_weight_dict.update({
+                    f"{k}_{i}": v for k, v in panoptic_weight_dict.items()
+                })
+            weight_dict.update(aux_weight_dict)
+
+        losses = ["labels", "masks"]
+        aux_losses = ["labels", "masks"]
+        if rank_weight > 0:
+            losses.append("labels_rank")
+        if objectness_weight > 0:
+            losses.append("objectness")
+
+        self.criterion = SetCriterion(
+            matcher=matcher,
+            weight_dict=weight_dict,
+            # NVPanoptix3Dv2 uses sigmoid labels, where eos_coef is inactive.
+            eos_coef=0.1,
+            losses=losses,
+            aux_losses=aux_losses,
+            num_points=num_points,
+            label_mode=label_mode,
+            objectness_no_object_weight=objectness_no_object_weight,
+            objectness_ignore_overlap_threshold=(
+                objectness_ignore_overlap_threshold
+            ),
+        )
+
+        self.metric_depth_weight = metric_depth_weight
+        self.metric_depth_loss = MetricDepthLoss(
+            silog_weight=metric_silog_weight,
+            absrel_weight=metric_absrel_weight,
+            silog_lambda=metric_silog_lambda,
+            min_depth=metric_min_depth,
+            max_depth=metric_max_depth,
+        ) if metric_depth_weight > 0 else None
+
+    def prepare_targets(
+        self,
+        gts: List[Dict],
+        classes: List[str],
+        device: torch.device,
+    ) -> List[Dict[str, torch.Tensor]]:
+        """Convert collated multi-view GT into SetCriterion format.
+
+        Args:
+            gts: list of S view dicts, each with batched tensors:
+                 ``pan_inst_id`` (B, H, W) and ``pan_cls_id`` (B, H, W).
+            classes: class name list of length C.
+            device: target device.
+
+        Returns:
+            list of B target dicts, each containing:
+              - ``labels``:      (N_inst,)       int64 class indices
+              - ``masks``:       (N_inst, S, H, W) float32 binary masks
+              - ``output_mask``: (C,) bool — enabled ScanNet++ classes
+              - ``valid_panoptic_mask``: (S, H, W) bool — pixels eligible
+                for Hungarian mask costs and BCE/Dice supervision
+              - ``ignored_panoptic_mask``: (S, H, W) bool — void or disabled
+                pixels that must not create negative objectness targets
+        """
+        num_classes = len(classes)
+        S = len(gts)
+        B = gts[0]["pan_inst_id"].shape[0]
+        H, W = gts[0]["pan_inst_id"].shape[1:]
+        output_mask = torch.ones(num_classes, dtype=torch.bool, device=device)
+        # Exclude broad catch-all classes from the native ScanNet++ taxonomy.
+        ignore_idx = {
+            i for i, name in enumerate(classes) if name in IGNORE_CLASS_NAMES
+        }
+        for i in ignore_idx:
+            output_mask[i] = False
+
+        targets = []
+        for b in range(B):
+            inst_maps = torch.stack([
+                gts[v]["pan_inst_id"][b].to(device=device)
+                for v in range(S)
+            ])
+            cls_maps = torch.stack([
+                gts[v]["pan_cls_id"][b].to(device=device)
+                for v in range(S)
+            ])
+
+            annotated = inst_maps != 0
+            class_in_range = (cls_maps >= 0) & (cls_maps < num_classes)
+            class_enabled = torch.zeros_like(class_in_range)
+            if class_in_range.any():
+                class_enabled[class_in_range] = output_mask[
+                    cls_maps[class_in_range].long()
+                ]
+
+            valid_panoptic_mask = annotated & class_enabled
+            # ScanNet++ panoptic id 0 is the void/unlabelled sentinel. Treat
+            # the full complement as ignored rather than semantic background.
+            ignored_panoptic_mask = ~valid_panoptic_mask
+
+            all_uids = torch.unique(inst_maps[valid_panoptic_mask]).sort().values
+
+            labels = []
+            masks = []
+            valid_uids = []
+            for uid_tensor in all_uids:
+                uid = int(uid_tensor.item())
+                mv_mask_bool = (
+                    (inst_maps == uid_tensor) & valid_panoptic_mask
+                )
+                cls_idx = int(cls_maps[mv_mask_bool][0].item())
+                mv_mask = mv_mask_bool.to(dtype=torch.float32)
+
+                labels.append(cls_idx)
+                masks.append(mv_mask)
+                valid_uids.append(uid)
+
+            if not labels:
+                targets.append({
+                    "labels": torch.zeros(0, dtype=torch.long, device=device),
+                    "masks": torch.zeros(0, S, H, W, device=device),
+                    "output_mask": output_mask,
+                    "valid_panoptic_mask": valid_panoptic_mask,
+                    "ignored_panoptic_mask": ignored_panoptic_mask,
+                    "instance_uids": [],
+                })
+            else:
+                targets.append({
+                    "labels": torch.tensor(labels, dtype=torch.long, device=device),
+                    "masks": torch.stack(masks).to(device),
+                    "output_mask": output_mask,
+                    "valid_panoptic_mask": valid_panoptic_mask,
+                    "ignored_panoptic_mask": ignored_panoptic_mask,
+                    "instance_uids": valid_uids,
+                })
+
+        return targets
+
+    def forward(
+        self,
+        gts: List[Dict],
+        panoptic_output: Dict[str, torch.Tensor],
+        classes: List[str],
+        geometry_output: Optional[Dict[str, torch.Tensor]] = None,
+        gt_depth: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        """Compute the combined panoptic and optional metric-depth loss.
+
+        Args:
+            gts:              list of GT dicts per batch element
+            panoptic_output:  dict with pred_logits, pred_masks, aux_outputs
+            classes:          list of class names
+            geometry_output:  optional dict with depth, metric_depth, metric_points, etc.
+            gt_depth:         optional [B, S, H, W] metric GT depth in metres
+
+        Returns:
+            (total_loss, loss_details)
+        """
+        device = panoptic_output["pred_logits"].device
+        targets = self.prepare_targets(gts, classes, device)
+
+        # Panoptic loss (classification + mask)
+        losses, _ = self.criterion(panoptic_output, targets)
+
+        total_loss = sum(
+            losses[k] * self.criterion.weight_dict.get(k, 1.0)
+            for k in losses
+            if k in self.criterion.weight_dict
+        )
+
+        loss_details = {"panoptic_loss": total_loss.detach()}
+        loss_details.update({k: v.detach() for k, v in losses.items()})
+
+        # Metric depth loss (MetricScaleHead supervision)
+        if (
+            self.metric_depth_loss is not None and
+            geometry_output is not None and
+            gt_depth is not None
+        ):
+            metric_depth = geometry_output.get("metric_depth")
+            if metric_depth is not None:
+                metric_losses = self.metric_depth_loss(
+                    metric_depth, gt_depth,
+                )
+                total_loss = (
+                    total_loss +
+                    self.metric_depth_weight * metric_losses["loss_metric_total"]
+                )
+                loss_details.update({k: v.detach() for k, v in metric_losses.items()})
+
+        return total_loss, loss_details

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/mAP.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/mAP.py
@@ -1,0 +1,405 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""mAP, mAP50, and mAP25 for 3D instance segmentation.
+
+The implementation follows the SegVGGT/mmdet3d ScanNet instance-segmentation
+protocol: class-aware matching, ScanNet AP integration, and ignored false
+positives when most of a prediction lies in void.  mAP averages AP at IoU
+thresholds 0.50:0.05:0.90; mAP50 and mAP25 use their named thresholds.
+
+Only the two operations needed by NVPanoptix3Dv2 evaluation are exposed:
+
+* :func:`prepare_instance_map_sample` converts one multi-view prediction and
+  its ground truth into a compact intersection table.
+* :func:`evaluate_instance_map_segvggt` aggregates those tables into mAP,
+  mAP50, and mAP25.
+
+Keeping intersections rather than full per-instance masks makes epoch-level
+evaluation practical for dense multi-view inputs and DDP object gathering.
+"""
+
+from typing import Dict, Iterable, List, Sequence
+
+import numpy as np
+
+
+_MAP_THRESHOLDS = np.round(np.arange(0.50, 0.95, 0.05), 2)
+
+
+def map_ids(values: np.ndarray, ids: np.ndarray) -> np.ndarray:
+    """Map arbitrary positive segment IDs to dense IDs in ``[1, len(ids)]``."""
+    values = np.asarray(values).reshape(-1)
+    dense = np.zeros(values.shape, dtype=np.int32)
+    if ids.size == 0:
+        return dense
+
+    order = np.argsort(ids)
+    sorted_ids = ids[order]
+    positions = np.searchsorted(sorted_ids, values)
+    valid = positions < sorted_ids.size
+    valid_indices = np.flatnonzero(valid)
+    valid[valid_indices] &= (
+        sorted_ids[positions[valid_indices]] == values[valid_indices]
+    )
+    # Dense indices follow the metadata order, not the sorted-ID order.
+    dense[valid] = order[positions[valid]] + 1
+    return dense
+
+
+def ground_truth_segments(
+    instance_ids: np.ndarray,
+    class_ids: np.ndarray,
+    num_categories: int,
+    evaluated_category_ids: Sequence[int],
+) -> List[Dict[str, int]]:
+    """Infer labels for non-background GT instances in evaluated classes."""
+    evaluated_ids = set(evaluated_category_ids)
+    valid = (
+        (instance_ids > 0) &
+        (class_ids >= 0) &
+        (class_ids < num_categories)
+    )
+    valid_instance_ids = instance_ids[valid]
+    valid_class_ids = class_ids[valid]
+    if valid_instance_ids.size == 0:
+        return []
+
+    # Class IDs are invariant for a scene-level instance UID. Selecting the
+    # first valid occurrence avoids constructing one full-resolution bool mask
+    # per instance while retaining deterministic behavior.
+    unique_ids, first_indices = np.unique(
+        valid_instance_ids, return_index=True,
+    )
+    segments = []
+    for instance_id, first_index in zip(unique_ids, first_indices):
+        category_id = int(valid_class_ids[first_index])
+        if category_id in evaluated_ids:
+            segments.append({
+                "id": int(instance_id),
+                "category_id": category_id,
+            })
+    return segments
+
+
+def prepare_instance_map_sample(
+    pred_pan: np.ndarray,
+    pred_segments: Sequence[Dict],
+    gt_instance_ids: np.ndarray,
+    gt_class_ids: np.ndarray,
+    *,
+    num_categories: int,
+    evaluated_category_ids: Iterable[int],
+    min_points: int = 100,
+) -> Dict[int, Dict[str, np.ndarray]]:
+    """Build the compact matching data for one multi-view sample.
+
+    Args:
+        pred_pan: Predicted segment-ID map with shape ``[S, H, W]``.
+        pred_segments: Metadata containing ``id``, ``category_id``, and
+            ``score`` for every predicted segment.
+        gt_instance_ids: Ground-truth instance-ID map, shaped like
+            ``pred_pan``. Zero denotes background/void.
+        gt_class_ids: Dense ground-truth category IDs, shaped like
+            ``gt_instance_ids``.
+        num_categories: Size of the dense category vocabulary.
+        evaluated_category_ids: Category IDs included in instance mAP. For a
+            panoptic taxonomy this should contain only ``isthing`` classes.
+        min_points: Predictions and GT instances smaller than this are ignored.
+
+    Returns:
+        A per-category dictionary of scores, areas, intersections, and void
+        intersections. Its size depends on the number of instances rather
+        than the number of input pixels.
+    """
+    pred_flat = np.asarray(pred_pan, dtype=np.int64).reshape(-1)
+    gt_inst_flat = np.asarray(gt_instance_ids, dtype=np.int64).reshape(-1)
+    gt_cls_flat = np.asarray(gt_class_ids, dtype=np.int64).reshape(-1)
+    if pred_flat.shape != gt_inst_flat.shape or gt_inst_flat.shape != gt_cls_flat.shape:
+        raise ValueError(
+            "pred_pan, gt_instance_ids, and gt_class_ids must contain the "
+            f"same number of points, got {pred_flat.size}, "
+            f"{gt_inst_flat.size}, and {gt_cls_flat.size}"
+        )
+    if num_categories <= 0:
+        raise ValueError(f"num_categories must be positive, got {num_categories}")
+    if min_points <= 0:
+        raise ValueError(f"min_points must be positive, got {min_points}")
+
+    evaluated_ids = tuple(dict.fromkeys(int(cid) for cid in evaluated_category_ids))
+    if any(cid < 0 or cid >= num_categories for cid in evaluated_ids):
+        raise ValueError(
+            f"evaluated category IDs must be in [0, {num_categories}), "
+            f"got {evaluated_ids}"
+        )
+
+    pred_metadata = []
+    seen_pred_ids = set()
+    for segment in pred_segments:
+        segment_id = int(segment["id"])
+        category_id = int(segment["category_id"])
+        if segment_id <= 0 or segment_id in seen_pred_ids:
+            raise ValueError(f"predicted segment IDs must be unique and positive: {segment_id}")
+        seen_pred_ids.add(segment_id)
+        if not 0 <= category_id < num_categories:
+            continue
+        pred_metadata.append({
+            "id": segment_id,
+            "category_id": category_id,
+            "score": float(segment["score"]),
+        })
+
+    gt_metadata = ground_truth_segments(
+        gt_inst_flat, gt_cls_flat, num_categories, evaluated_ids,
+    )
+    pred_ids = np.asarray([s["id"] for s in pred_metadata], dtype=np.int64)
+    gt_ids = np.asarray([s["id"] for s in gt_metadata], dtype=np.int64)
+    pred_dense = map_ids(pred_flat, pred_ids)
+    gt_dense = map_ids(gt_inst_flat, gt_ids)
+
+    pred_areas = np.bincount(pred_dense, minlength=pred_ids.size + 1)
+    gt_areas = np.bincount(gt_dense, minlength=gt_ids.size + 1)
+    pair_ids = pred_dense.astype(np.int64) * (gt_ids.size + 1) + gt_dense
+    intersections = np.bincount(
+        pair_ids,
+        minlength=(pred_ids.size + 1) * (gt_ids.size + 1),
+    ).reshape(pred_ids.size + 1, gt_ids.size + 1)
+
+    cache: Dict[int, Dict[str, np.ndarray]] = {}
+    for category_id in evaluated_ids:
+        pred_indices = np.asarray([
+            index + 1
+            for index, segment in enumerate(pred_metadata)
+            if segment["category_id"] == category_id and
+            pred_areas[index + 1] >= min_points
+        ], dtype=np.int64)
+        all_category_gt_indices = np.asarray([
+            index + 1
+            for index, segment in enumerate(gt_metadata)
+            if segment["category_id"] == category_id
+        ], dtype=np.int64)
+        gt_indices = all_category_gt_indices[
+            gt_areas[all_category_gt_indices] >= min_points
+        ]
+        small_gt_indices = all_category_gt_indices[
+            gt_areas[all_category_gt_indices] < min_points
+        ]
+        if pred_indices.size == 0 and gt_indices.size == 0:
+            continue
+
+        scores_by_dense_id = {
+            index + 1: segment["score"]
+            for index, segment in enumerate(pred_metadata)
+        }
+        cache[category_id] = {
+            "pred_scores": np.asarray(
+                [scores_by_dense_id[int(i)] for i in pred_indices],
+                dtype=np.float64,
+            ),
+            "pred_areas": pred_areas[pred_indices].astype(np.int64, copy=False),
+            "gt_areas": gt_areas[gt_indices].astype(np.int64, copy=False),
+            "inter": intersections[np.ix_(pred_indices, gt_indices)].astype(
+                np.int64, copy=False,
+            ),
+            # Background, invalid GT, and non-evaluated categories are void.
+            # Same-class GT smaller than the protocol's region threshold is
+            # ignored as well.
+            "void_inter": (
+                intersections[pred_indices, 0] +
+                intersections[np.ix_(pred_indices, small_gt_indices)].sum(axis=1)
+            ).astype(np.int64, copy=False),
+        }
+    return cache
+
+
+def ap_for_category(
+    sample_caches: Sequence[Dict[int, Dict[str, np.ndarray]]],
+    category_id: int,
+    iou_threshold: float,
+) -> float:
+    """Compute AP for one category and one IoU threshold."""
+    y_true = []
+    y_score = []
+    has_gt = False
+    has_pred = False
+    hard_false_negatives = 0
+    pred_visited = {}
+
+    for sample_index, cache in enumerate(sample_caches):
+        category = cache.get(category_id)
+        if category is None:
+            continue
+        for pred_index in range(category["pred_scores"].shape[0]):
+            pred_visited[(sample_index, pred_index)] = False
+
+    for sample_index, cache in enumerate(sample_caches):
+        category = cache.get(category_id)
+        if category is None:
+            continue
+
+        pred_scores = category["pred_scores"]
+        pred_areas = category["pred_areas"]
+        gt_areas = category["gt_areas"]
+        intersections = category["inter"]
+        void_intersections = category["void_inter"]
+        num_predictions = pred_scores.shape[0]
+        num_ground_truth = gt_areas.shape[0]
+        has_gt |= num_ground_truth > 0
+        has_pred |= num_predictions > 0
+
+        current_true = np.ones(num_ground_truth, dtype=np.float64)
+        current_score = np.full(num_ground_truth, -np.inf, dtype=np.float64)
+        current_match = np.zeros(num_ground_truth, dtype=bool)
+        duplicate_true = []
+        duplicate_score = []
+
+        for gt_index in range(num_ground_truth):
+            found_match = False
+            for pred_index in range(num_predictions):
+                if pred_visited[(sample_index, pred_index)]:
+                    continue
+                intersection = int(intersections[pred_index, gt_index])
+                union = int(
+                    pred_areas[pred_index] + gt_areas[gt_index] - intersection
+                )
+                if union <= 0 or intersection / union <= iou_threshold:
+                    continue
+
+                confidence = float(pred_scores[pred_index])
+                if current_match[gt_index]:
+                    previous = current_score[gt_index]
+                    current_score[gt_index] = max(previous, confidence)
+                    duplicate_true.append(0.0)
+                    duplicate_score.append(min(previous, confidence))
+                else:
+                    found_match = True
+                    current_match[gt_index] = True
+                    current_score[gt_index] = confidence
+                    pred_visited[(sample_index, pred_index)] = True
+            if not found_match:
+                hard_false_negatives += 1
+
+        current_true = current_true[current_match]
+        current_score = current_score[current_match]
+        if duplicate_true:
+            current_true = np.concatenate([
+                current_true, np.asarray(duplicate_true, dtype=np.float64),
+            ])
+            current_score = np.concatenate([
+                current_score, np.asarray(duplicate_score, dtype=np.float64),
+            ])
+
+        # Unmatched predictions are false positives unless most of their area
+        # is void, matching the ScanNet ignore rule.
+        for pred_index in range(num_predictions):
+            if pred_visited[(sample_index, pred_index)]:
+                continue
+            overlaps_gt = False
+            for gt_index in range(num_ground_truth):
+                intersection = int(intersections[pred_index, gt_index])
+                union = int(
+                    pred_areas[pred_index] + gt_areas[gt_index] - intersection
+                )
+                if union > 0 and intersection / union > iou_threshold:
+                    overlaps_gt = True
+                    break
+            if overlaps_gt:
+                continue
+
+            ignored_fraction = (
+                int(void_intersections[pred_index]) /
+                max(int(pred_areas[pred_index]), 1)
+            )
+            if ignored_fraction <= iou_threshold:
+                current_true = np.append(current_true, 0.0)
+                current_score = np.append(
+                    current_score, float(pred_scores[pred_index]),
+                )
+
+        y_true.append(current_true)
+        y_score.append(current_score)
+
+    if not has_gt:
+        return float("nan")
+    if not has_pred:
+        return 0.0
+
+    y_true_array = np.concatenate(y_true) if y_true else np.zeros(0)
+    y_score_array = np.concatenate(y_score) if y_score else np.zeros(0)
+    if y_score_array.size == 0:
+        return 0.0
+
+    order = np.argsort(y_score_array)
+    sorted_true = y_true_array[order]
+    sorted_scores = y_score_array[order]
+    true_cumsum = np.cumsum(sorted_true)
+    _, unique_indices = np.unique(sorted_scores, return_index=True)
+
+    precision = np.zeros(len(unique_indices) + 1, dtype=np.float64)
+    recall = np.zeros(len(unique_indices) + 1, dtype=np.float64)
+    num_examples = len(sorted_scores)
+    num_true_examples = float(true_cumsum[-1]) if true_cumsum.size else 0.0
+    cumsum_padded = np.append(true_cumsum, 0.0)
+    for result_index, score_index in enumerate(unique_indices):
+        cumsum = cumsum_padded[score_index - 1]
+        true_positives = num_true_examples - cumsum
+        false_positives = num_examples - score_index - true_positives
+        false_negatives = cumsum + hard_false_negatives
+        precision_denominator = true_positives + false_positives
+        recall_denominator = true_positives + false_negatives
+        precision[result_index] = (
+            true_positives / precision_denominator
+            if precision_denominator > 0 else 0.0
+        )
+        recall[result_index] = (
+            true_positives / recall_denominator
+            if recall_denominator > 0 else 0.0
+        )
+
+    precision[-1] = 1.0
+    recall[-1] = 0.0
+    recall_for_convolution = np.concatenate(([recall[0]], recall, [0.0]))
+    step_widths = np.convolve(
+        recall_for_convolution, [-0.5, 0.0, 0.5], "valid",
+    )
+    return float(np.dot(precision, step_widths))
+
+
+def finite_mean(values: Sequence[float]) -> float:
+    """Mean finite values, returning zero when no evaluated GT is present."""
+    finite = [value for value in values if np.isfinite(value)]
+    return float(np.mean(finite)) if finite else 0.0
+
+
+def evaluate_instance_map_segvggt(
+    sample_caches: Sequence[Dict[int, Dict[str, np.ndarray]]],
+    evaluated_category_ids: Iterable[int],
+) -> Dict[str, float]:
+    """Aggregate prepared samples into mAP, mAP50, and mAP25 percentages."""
+    category_ids = tuple(dict.fromkeys(int(cid) for cid in evaluated_category_ids))
+
+    ap50 = [
+        ap_for_category(sample_caches, category_id, 0.50)
+        for category_id in category_ids
+    ]
+    ap25 = [
+        ap_for_category(sample_caches, category_id, 0.25)
+        for category_id in category_ids
+    ]
+    ap = []
+    for category_id in category_ids:
+        category_ap = [
+            ap_for_category(sample_caches, category_id, float(threshold))
+            for threshold in _MAP_THRESHOLDS
+        ]
+        ap.append(
+            finite_mean(category_ap)
+            if any(np.isfinite(value) for value in category_ap)
+            else float("nan")
+        )
+
+    return {
+        "mAP": 100.0 * finite_mean(ap),
+        "mAP50": 100.0 * finite_mean(ap50),
+        "mAP25": 100.0 * finite_mean(ap25),
+    }

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/matcher.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/panoptic/matcher.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Modified from Mask2Former (https://github.com/facebookresearch/Mask2Former) for multi-view outputs
+
+"""Hungarian matching between GT and predicted masks for supervision."""
+
+import torch
+import torch.nn.functional as F
+from scipy.optimize import linear_sum_assignment
+from torch import nn
+
+from nvidia_tao_pytorch.cv.mask2former.utils.point_features import point_sample
+
+
+def batch_dice_loss_masked(
+    inputs: torch.Tensor,
+    targets: torch.Tensor,
+    valid: torch.Tensor,
+):
+    """Pairwise Dice cost over annotated, non-ignored points only.
+
+    ``valid`` is shared by every predicted/target mask in one sample because
+    panoptic annotation validity is a property of the source pixels, not of
+    an individual instance.  Returning zero when no sampled point is valid
+    leaves assignment to the classification cost instead of treating void as
+    background.
+    """
+    inputs = inputs.sigmoid()
+    valid = valid.to(dtype=inputs.dtype).flatten()
+    targets = targets * valid.unsqueeze(0)
+    inputs = inputs * valid.unsqueeze(0)
+    numerator = 2 * torch.einsum("nc,mc->nm", inputs, targets)
+    denominator = inputs.sum(-1)[:, None] + targets.sum(-1)[None, :]
+    loss = 1 - (numerator + 1) / (denominator + 1)
+    return loss * (valid.sum() > 0).to(dtype=loss.dtype)
+
+
+batch_dice_loss_masked_jit = torch.jit.script(batch_dice_loss_masked)
+
+
+def batch_sigmoid_ce_loss_masked(
+    inputs: torch.Tensor,
+    targets: torch.Tensor,
+    valid: torch.Tensor,
+):
+    """Pairwise BCE cost over annotated, non-ignored points only."""
+    valid = valid.to(dtype=inputs.dtype).flatten()
+    pos = F.binary_cross_entropy_with_logits(
+        inputs, torch.ones_like(inputs), reduction="none"
+    ) * valid.unsqueeze(0)
+    neg = F.binary_cross_entropy_with_logits(
+        inputs, torch.zeros_like(inputs), reduction="none"
+    ) * valid.unsqueeze(0)
+    loss = torch.einsum("nc,mc->nm", pos, targets) + torch.einsum(
+        "nc,mc->nm", neg, (1 - targets)
+    )
+    return loss / valid.sum().clamp_min(1.0)
+
+
+batch_sigmoid_ce_loss_masked_jit = torch.jit.script(
+    batch_sigmoid_ce_loss_masked
+)
+
+
+class HungarianMatcher(nn.Module):
+    """Assignment between targets and predictions via the Hungarian algorithm.
+
+    There are typically more predictions than targets; unmatched predictions
+    are treated as no-object.
+    """
+
+    def __init__(
+        self,
+        cost_class: float = 1,
+        cost_mask: float = 1,
+        cost_dice: float = 1,
+        num_points: int = 0,
+        label_mode: str = "softmax",
+    ):
+        super().__init__()
+        self.cost_class = cost_class
+        self.cost_mask = cost_mask
+        self.cost_dice = cost_dice
+        self.num_points = num_points
+        self.label_mode = label_mode
+        if cost_class == 0 and cost_mask == 0 and cost_dice == 0:
+            raise ValueError("At least one matching cost must be nonzero")
+
+    @torch.no_grad()
+    def memory_efficient_forward(self, outputs, targets):
+        """Solve the assignment one batch element at a time to bound peak memory."""
+        bs, num_queries = outputs["pred_logits"].shape[:2]
+        indices = []
+
+        for b in range(bs):
+            tgt_ids = targets[b]["labels"]
+
+            if len(tgt_ids) == 0:
+                indices.append(([], []))
+                continue
+
+            # Classification matching cost. This has to score class agreement
+            # with the same objective that is back-propagated, or the bipartite
+            # assignment optimises a different target than the criterion.
+            # ``sigmoid`` mode uses the Deformable-DETR / MaskDINO focal cost
+            # (positive minus negative, fp32 for log stability); ``softmax``
+            # mode uses Mask2Former's negative-probability cost.
+            cls_logits = outputs["pred_logits"][b].float()
+            if self.label_mode == "sigmoid":
+                alpha, gamma = 0.25, 2.0
+                prob = cls_logits.sigmoid()
+                neg_cost_class = (
+                    (1 - alpha) * (prob ** gamma) * (-(1 - prob).clamp_min(1e-8).log())
+                )
+                pos_cost_class = (
+                    alpha * ((1 - prob) ** gamma) * (-prob.clamp_min(1e-8).log())
+                )
+                cost_class = pos_cost_class[:, tgt_ids] - neg_cost_class[:, tgt_ids]
+            else:
+                out_prob = cls_logits.softmax(-1)
+                cost_class = -out_prob[:, tgt_ids]
+
+            out_mask = outputs["pred_masks"][b]
+            tgt_mask = targets[b]["masks"].to(out_mask)
+            valid_mask = targets[b]["valid_panoptic_mask"].to(
+                device=out_mask.device,
+            )
+
+            out_mask = out_mask.transpose(0, 1)
+            if out_mask.shape[1] != tgt_mask.shape[1]:
+                raise ValueError("Outputs and targets must have the same number of views")
+            if valid_mask.shape != tgt_mask.shape[1:]:
+                raise ValueError("valid_panoptic_mask must have shape [views, H, W]")
+            n_out, num_views = out_mask.shape[:2]
+            n_tgt = tgt_mask.shape[0]
+
+            tgt_mask = tgt_mask.flatten(0, 1).unsqueeze(1)
+            out_mask = out_mask.flatten(0, 1).unsqueeze(1)
+
+            point_coords = torch.rand(
+                num_views, self.num_points, 2, device=out_mask.device
+            )
+
+            tgt_mask = point_sample(
+                tgt_mask,
+                point_coords.repeat(n_tgt, 1, 1),
+                align_corners=False,
+            ).squeeze(1)
+            tgt_mask = tgt_mask.unflatten(0, (n_tgt, num_views)).flatten(-2)
+
+            out_mask = point_sample(
+                out_mask,
+                point_coords.repeat(n_out, 1, 1),
+                align_corners=False,
+            ).squeeze(1)
+            out_mask = out_mask.unflatten(0, (n_out, num_views)).flatten(-2)
+
+            valid_points = point_sample(
+                valid_mask.float().unsqueeze(1),
+                point_coords,
+                mode="nearest",
+                align_corners=False,
+            ).squeeze(1).flatten()
+
+            with torch.amp.autocast("cuda", enabled=False):
+                out_mask = out_mask.float()
+                tgt_mask = tgt_mask.float()
+                valid_points = valid_points.float()
+                cost_mask = batch_sigmoid_ce_loss_masked_jit(
+                    out_mask, tgt_mask, valid_points,
+                )
+                cost_dice = batch_dice_loss_masked_jit(
+                    out_mask, tgt_mask, valid_points,
+                )
+
+            C = (
+                self.cost_mask * cost_mask +
+                self.cost_class * cost_class +
+                self.cost_dice * cost_dice
+            )
+            C = C.reshape(num_queries, -1).cpu()
+            C[~torch.isfinite(C)] = 1e4
+            indices.append(linear_sum_assignment(C))
+
+        return [
+            (
+                torch.as_tensor(i, dtype=torch.int64, device=outputs["pred_logits"].device),
+                torch.as_tensor(j, dtype=torch.int64, device=outputs["pred_logits"].device),
+            )
+            for i, j in indices
+        ]
+
+    @torch.no_grad()
+    def forward(self, outputs, targets):
+        """Match predicted queries to targets and return the per-sample index pairs."""
+        return self.memory_efficient_forward(outputs, targets)
+
+    def __repr__(self, _repr_indent=4):
+        """Render the configured matching costs."""
+        head = "Matcher " + self.__class__.__name__
+        body = [
+            "cost_class: {}".format(self.cost_class),
+            "cost_mask: {}".format(self.cost_mask),
+            "cost_dice: {}".format(self.cost_dice),
+        ]
+        lines = [head] + [" " * _repr_indent + line for line in body]
+        return "\n".join(lines)

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Losses, mask helpers, and canonical point metrics for reasoning."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/losses.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/losses.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Losses for NVPanoptix3Dv2 reasoning training."""
+
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.metric_depth import MetricDepthLoss
+
+
+def dice_loss_prob(prob: Tensor, target: Tensor, eps: float = 1.0) -> Tensor:
+    """Per-row soft Dice loss for flattened probability/target tensors."""
+    num = 2.0 * (prob * target).sum(-1) + eps
+    den = prob.sum(-1) + target.sum(-1) + eps
+    return 1.0 - num / den
+
+
+class NVPanoptix3Dv2ReasoningLoss(nn.Module):
+    """Text CE plus best-query SAM mask and score losses.
+
+    SAM3 emits many object queries for one prompt. For the single-target
+    task, the target query is selected by the lowest detached mask cost against
+    the GT instance. That query receives BCE and Dice supervision, while the
+    SAM query scores receive a one-hot BCE target.
+    """
+
+    def __init__(
+        self,
+        text_weight: float = 1.0,
+        mask_weight: float = 20.0,
+        dice_weight: float = 1.0,
+        score_weight: float = 1.0,
+        metric_weight: float = 0.0,
+        metric_silog_weight: float = 1.0,
+        metric_absrel_weight: float = 0.1,
+        metric_silog_lambda: float = 0.85,
+        metric_min_depth: float = 0.1,
+        metric_max_depth: float = 30.0,
+    ):
+        super().__init__()
+        self.text_weight = float(text_weight)
+        self.mask_weight = float(mask_weight)
+        self.dice_weight = float(dice_weight)
+        self.score_weight = float(score_weight)
+        self.metric_weight = float(metric_weight)
+        self.metric_depth_criterion = MetricDepthLoss(
+            silog_weight=metric_silog_weight,
+            absrel_weight=metric_absrel_weight,
+            silog_lambda=metric_silog_lambda,
+            min_depth=metric_min_depth,
+            max_depth=metric_max_depth,
+        ) if self.metric_weight > 0 else None
+
+    @staticmethod
+    def text_loss(lm_logits: Tensor, labels: Tensor) -> Tensor:
+        """Shifted causal-LM cross entropy."""
+        shift_logits = lm_logits[:, :-1, :].contiguous()
+        shift_labels = labels[:, 1:].contiguous()
+        return F.cross_entropy(
+            shift_logits.view(-1, shift_logits.size(-1)),
+            shift_labels.view(-1),
+            ignore_index=-100,
+        )
+
+    @staticmethod
+    def resize_gt(gt_masks: Tensor, size: Tuple[int, int]) -> Tensor:
+        """Resize ground-truth masks to the prediction resolution."""
+        if gt_masks.shape[-2:] == size:
+            return gt_masks.float()
+        return F.interpolate(gt_masks[:, None].float(), size=size, mode="area")[:, 0]
+
+    def sam_loss(
+        self,
+        pred_masks: Tensor,
+        pred_logits: Tensor,
+        gt_masks: Tensor,
+        valid: Tensor,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Return ``(bce, dice, score, best_idx)`` for valid samples."""
+        B, Q, h, w = pred_masks.shape
+        device = pred_masks.device
+        if not bool(valid.any()):
+            zero = pred_masks.sum() * 0.0
+            return zero, zero, zero, torch.full((B,), -1, dtype=torch.long, device=device)
+
+        gt = self.resize_gt(gt_masks.to(device), (h, w))
+        pred_flat = pred_masks.reshape(B, Q, h * w)
+        gt_flat = gt.reshape(B, 1, h * w).expand(B, Q, h * w)
+
+        bce_q = F.binary_cross_entropy_with_logits(pred_flat, gt_flat, reduction="none").mean(-1)
+        dice_q = dice_loss_prob(pred_flat.sigmoid(), gt_flat)
+        cost = bce_q + dice_q
+        best_idx = cost.detach().argmin(dim=1)
+
+        valid = valid.to(device).bool()
+        b = torch.arange(B, device=device)
+        bce = bce_q[b[valid], best_idx[valid]].mean()
+        dice = dice_q[b[valid], best_idx[valid]].mean()
+
+        score_tgt = torch.zeros_like(pred_logits)
+        score_tgt[b[valid], best_idx[valid]] = 1.0
+        score = F.binary_cross_entropy_with_logits(pred_logits[valid], score_tgt[valid])
+        best_idx = torch.where(valid, best_idx, torch.full_like(best_idx, -1))
+        return bce, dice, score, best_idx
+
+    def metric_depth_loss(
+        self,
+        out: Dict[str, object],
+        gt_depth: Optional[Tensor],
+    ) -> Tensor:
+        """SILog + AbsRel supervision on the metric depth, when the head is enabled."""
+        metric_depth = out.get("metric_depth")
+        if self.metric_depth_criterion is None or gt_depth is None or metric_depth is None:
+            device = out["pred_masks"].device
+            return torch.zeros((), device=device)
+        if metric_depth.dim() == 5:
+            metric_depth = metric_depth.squeeze(-1)
+        gt = gt_depth.to(metric_depth.device).float()
+        if metric_depth.shape[-2:] != gt.shape[-2:]:
+            B, S = metric_depth.shape[:2]
+            metric_depth = F.interpolate(
+                metric_depth.reshape(B * S, 1, *metric_depth.shape[2:]),
+                size=tuple(gt.shape[-2:]),
+                mode="bilinear",
+                align_corners=False,
+            ).reshape(B, S, *gt.shape[-2:])
+        return self.metric_depth_criterion(
+            metric_depth, gt,
+        )["loss_metric_total"]
+
+    def forward(
+        self,
+        out: Dict[str, object],
+        gt_masks: Tensor,
+        mask_valid: Tensor,
+        gt_depth: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Dict[str, float]]:
+        """Compute total loss and scalar logs."""
+        device = out["pred_masks"].device
+        if out.get("labels") is not None and self.text_weight > 0:
+            l_text = self.text_loss(out["lm_logits"], out["labels"])
+        else:
+            l_text = torch.zeros((), device=device)
+
+        valid = mask_valid.to(device).bool() & out["seg_valid"].to(device).bool()
+        l_bce, l_dice, l_score, best_idx = self.sam_loss(
+            out["pred_masks"], out["pred_logits"], gt_masks, valid
+        )
+        total = (
+            self.text_weight * l_text +
+            self.mask_weight * l_bce +
+            self.dice_weight * l_dice +
+            self.score_weight * l_score
+        )
+        l_metric = self.metric_depth_loss(out, gt_depth)
+        total = total + self.metric_weight * l_metric
+        logs = {
+            "loss_total": float(total.detach()),
+            "loss_text": float(l_text.detach()),
+            "loss_mask": float(l_bce.detach()),
+            "loss_dice": float(l_dice.detach()),
+            "loss_score": float(l_score.detach()),
+            "loss_metric": float(l_metric.detach()),
+            "n_mask_valid": float(valid.sum().item()),
+            "best_query_mean": (
+                float(best_idx[best_idx >= 0].float().mean())
+                if bool((best_idx >= 0).any()) else -1.0
+            ),
+        }
+        params = out.get("scale_shift_params")
+        if isinstance(params, dict) and "scale" in params:
+            logs["metric_scale_mean"] = float(params["scale"].detach().mean())
+        return total, logs

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/masks.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/masks.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mask utilities shared by the NVPanoptix3Dv2-Reasoning training path."""
+
+from torch import Tensor
+
+
+def build_target_masks(
+    pan_inst_id: Tensor,
+    target_inst_id: Tensor,
+) -> Tensor:
+    """Build ``[B, S, H, W]`` binary masks from per-view instance ids."""
+    tgt = target_inst_id.view(-1, 1, 1, 1)
+    return (pan_inst_id == tgt) & (tgt > 0)
+
+
+def gather_view_masks(
+    pan_inst_id: Tensor,
+    target_inst_id: Tensor,
+    sample_idx: Tensor,
+    view_idx: Tensor,
+) -> Tensor:
+    """Per-binding GT instance masks.
+
+    Args:
+        pan_inst_id: ``[B, S, H, W]`` per-view instance ids.
+        target_inst_id: ``[B]`` instance UID per sample.
+        sample_idx: ``[N]`` sample id per binding.
+        view_idx: ``[N]`` view id per binding.
+
+    Returns:
+        ``[N, H, W]`` boolean GT masks (``pan_inst_id == target`` at each binding's view).
+    """
+    gt_all = build_target_masks(pan_inst_id, target_inst_id)  # [B, S, H, W]
+    if sample_idx.numel() == 0:
+        _, _, H, W = gt_all.shape
+        return gt_all.new_zeros((0, H, W), dtype=gt_all.dtype)
+    return gt_all[sample_idx, view_idx]

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/score.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/utils/reasoning/score.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical-point-cloud metrics for reasoning segmentation.
+
+Each validation sample is scored once on a checkpoint-independent canonical
+point domain: valid metric-depth pixels in ``[view, y, x]`` order. Prediction
+and ground truth therefore always address identical points. The XYZ values are
+not needed for binary set IoU; their fixed validity and ordering are sufficient.
+
+Only the requested metrics are reported:
+
+* ``mIoU``: mean per-query point IoU.
+* ``mAP50``: fraction of queries whose point IoU is at least 0.50.
+* ``mAP25``: fraction of queries whose point IoU is at least 0.25.
+
+The threshold metrics retain the original benchmark's per-query hit-rate
+semantics under their requested names. Values are fractions in ``[0, 1]``.
+"""
+
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.reasoning.masks import (
+    build_target_masks,
+)
+
+
+def point_iou(pred: np.ndarray, gt: np.ndarray) -> float:
+    """Return binary set IoU for prediction and GT on identical points."""
+    pred = np.asarray(pred, dtype=bool).reshape(-1)
+    gt = np.asarray(gt, dtype=bool).reshape(-1)
+    if pred.shape != gt.shape:
+        raise ValueError(
+            f"prediction and GT must address identical points: {pred.shape} != {gt.shape}"
+        )
+    intersection = float(np.logical_and(pred, gt).sum())
+    union = float(np.logical_or(pred, gt).sum())
+    return 0.0 if union == 0.0 else intersection / union
+
+
+def aggregate(inter_union: Iterable[Tuple[float, float]]) -> Dict[str, float]:
+    """Aggregate intersection/union pairs into mIoU, mAP50, and mAP25."""
+    pairs = list(inter_union)
+    if not pairs:
+        return {}
+    ious = np.asarray([
+        0.0 if union == 0.0 else intersection / union
+        for intersection, union in pairs
+    ], dtype=np.float64)
+    return {
+        "mIoU": float(ious.mean()),
+        "mAP50": float((ious >= 0.50).mean()),
+        "mAP25": float((ious >= 0.25).mean()),
+    }
+
+
+class CanonicalPointCloudMetrics:
+    """Additive accumulator for canonical point-cloud reasoning metrics."""
+
+    def __init__(self):
+        self._iou_sum = 0.0
+        self._map50_hits = 0
+        self._map25_hits = 0
+        self._num_samples = 0
+
+    def add_counts(self, intersection: float, union: float) -> None:
+        """Add one query using its canonical-point intersection and union."""
+        iou = 0.0 if union == 0.0 else float(intersection) / float(union)
+        self._iou_sum += iou
+        self._map50_hits += int(iou >= 0.50)
+        self._map25_hits += int(iou >= 0.25)
+        self._num_samples += 1
+
+    def add(self, pred: np.ndarray, gt: np.ndarray) -> None:
+        """Add one query from binary masks defined on identical points."""
+        pred = np.asarray(pred, dtype=bool).reshape(-1)
+        gt = np.asarray(gt, dtype=bool).reshape(-1)
+        if pred.shape != gt.shape:
+            raise ValueError(
+                "prediction and GT must address identical points: "
+                f"{pred.shape} != {gt.shape}"
+            )
+        self.add_counts(
+            float(np.logical_and(pred, gt).sum()),
+            float(np.logical_or(pred, gt).sum()),
+        )
+
+    def raw_state(self) -> List[float]:
+        """Return the summable state used for DDP all-reduce."""
+        return [
+            self._iou_sum,
+            float(self._map50_hits),
+            float(self._map25_hits),
+            float(self._num_samples),
+        ]
+
+    def load_raw_state(self, state: Iterable[float]) -> None:
+        """Load a state previously returned by :meth:`raw_state`."""
+        values = list(state)
+        if len(values) != 4:
+            raise ValueError(f"expected four metric accumulators, got {len(values)}")
+        self._iou_sum = float(values[0])
+        self._map50_hits = int(round(float(values[1])))
+        self._map25_hits = int(round(float(values[2])))
+        self._num_samples = int(round(float(values[3])))
+
+    def compute(self) -> Dict[str, float]:
+        """Return only mIoU, mAP50, and mAP25."""
+        if self._num_samples == 0:
+            return {}
+        return {
+            "mIoU": self._iou_sum / self._num_samples,
+            "mAP50": self._map50_hits / self._num_samples,
+            "mAP25": self._map25_hits / self._num_samples,
+        }
+
+
+def score_batch_on_canonical_points(
+    meter: CanonicalPointCloudMetrics,
+    out,
+    pan_inst,
+    target_inst,
+    canonical_valid,
+    mask_threshold: float,
+) -> None:
+    """Score a multi-view batch on its fixed metric-depth point domain.
+
+    All views participate in the canonical domain. A predicted ``[SEG]`` mask
+    is inserted at its bound view; views without a binding remain empty. Every
+    positive-target sample is scored, so a missing ``[SEG]`` prediction becomes
+    an empty mask rather than silently disappearing from the metric.
+
+    Args:
+        meter: Destination metric accumulator.
+        out: Model outputs containing SAM ``pred_masks``, ``pred_logits``, and
+            binding indices ``seg_sample_idx`` / ``seg_view_idx``.
+        pan_inst: ``[B, S, H, W]`` canonical GT instance IDs.
+        target_inst: ``[B]`` target instance IDs.
+        canonical_valid: ``[B, S, H, W]`` mask of valid canonical depth points.
+        mask_threshold: Probability threshold for the selected SAM mask.
+    """
+    if pan_inst.shape != canonical_valid.shape:
+        raise ValueError(
+            "panoptic IDs and canonical validity must have identical shape: "
+            f"{tuple(pan_inst.shape)} != {tuple(canonical_valid.shape)}"
+        )
+    batch_size, num_views, height, width = pan_inst.shape
+    device = pan_inst.device
+    pred_by_sample = torch.zeros(
+        (batch_size, num_views, height, width),
+        dtype=torch.bool,
+        device=device,
+    )
+
+    sample_indices = out["seg_sample_idx"].to(device)
+    view_indices = out["seg_view_idx"].to(device)
+    num_bindings = int(sample_indices.numel())
+    if num_bindings:
+        pred_masks = out["pred_masks"]
+        pred_logits = out["pred_logits"]
+        selected_queries = pred_logits.float().argmax(dim=1)
+        selected_masks = pred_masks[
+            torch.arange(num_bindings, device=pred_masks.device),
+            selected_queries,
+        ]
+        probabilities = F.interpolate(
+            selected_masks.unsqueeze(1).float(),
+            size=(height, width),
+            mode="bilinear",
+            align_corners=False,
+        ).sigmoid()[:, 0].to(device)
+        predictions = probabilities > float(mask_threshold)
+        for binding in range(num_bindings):
+            sample = int(sample_indices[binding].item())
+            view = int(view_indices[binding].item())
+            pred_by_sample[sample, view] |= predictions[binding]
+
+    ground_truth = build_target_masks(pan_inst, target_inst)
+    canonical_valid = canonical_valid.to(device=device, dtype=torch.bool)
+    for sample in range(batch_size):
+        if int(target_inst[sample].item()) <= 0:
+            continue
+        valid = canonical_valid[sample]
+        if not bool(valid.any()):
+            raise ValueError(
+                f"canonical point cloud is empty for batch sample {sample}; "
+                "reasoning evaluation requires valid metric depth"
+            )
+        gt = ground_truth[sample][valid]
+        if not bool(gt.any()):
+            raise ValueError(
+                f"target instance {int(target_inst[sample].item())} has no points "
+                f"in the canonical cloud for batch sample {sample}"
+            )
+        pred = pred_by_sample[sample][valid]
+        intersection = float((pred & gt).sum().item())
+        union = float((pred | gt).sum().item())
+        meter.add_counts(intersection, union)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->

Adds the NVPanoptix3Dv2 task entrypoint, train/evaluate/inference/export scripts, shared training and evaluation utilities, and reference experiment specifications for the panoptic and reasoning variants.

### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->

NVPanoptix3Dv2 needs TAO-compatible task orchestration and configuration to expose its model and dataloaders through standard workflows.

This change provides:

- Panoptic training and evaluation on preprocessed ScanNet++ data.
- Reasoning segmentation training and evaluation from JSONL manifests.
- Shared metric-depth supervision across both variants.
- Panoptic Hungarian matching, mask losses, post-processing, and instance mAP metrics.
- Reasoning text, mask, score, and canonical point-cloud metrics.
- Reference configurations with consistent checkpointing, dataset paths, and runtime defaults.

### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->

Part of TAOVN-1251

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->

Yes.

Previously, NVPanoptix3Dv2 did not provide complete TAO task scripts or reference experiment specifications.

After this change, users can run the supported workflows with the included panoptic and reasoning specifications.

### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->

```
TruffleHog secret scan...................................................Passed
license header...........................................................Passed
pylint...................................................................Passed
pydocstyle...............................................................Passed
flake8...................................................................Passed
```

### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

Yes — portions were co-authored with an AI coding assistant.
-->

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Added TAO task workflows, shared training and evaluation utilities, and reference panoptic and reasoning configurations for NVPanoptix3Dv2.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [x] All tests pass locally
- [ ] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->

Suggested review order:
1. experiment_specs/spec_panoptic.yaml and spec_reasoning.yaml for the supported workflows and defaults.
2. scripts/ for variant selection and TAO Trainer integration.
3. utils/metric_depth.py for the objective shared by both variants.
4. utils/panoptic/ and utils/reasoning/ for variant-specific losses and evaluation metrics.
5. entrypoint/nvpanoptix3d_v2.py for task discovery and dispatch.
Important design decisions: