### PR TITLE
[TAOVN-1251][Feature] Add NVPanoptix3Dv2 export and unit tests

### DIFF
--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 ONNX export."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/onnx_exporter.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/onnx_exporter.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ONNX exporter for the NVPanoptix3Dv2 panoptic variant.
+
+The graph takes one multi-view image tensor and returns the panoptic head's
+logits and masks alongside VGGT's geometry, covering everything
+``predict_step`` consumes. ``panoptic_inference`` stays outside the graph: it is
+threshold-driven, emits variable-length segment tables, and is cheap next to the
+backbone.
+
+Four things do not survive tracing, and each is handled here rather than in the
+model:
+
+1. The vocabulary is text, which ONNX cannot take as an input. It is encoded
+   once up front and baked in as a constant ``[C, D]`` matrix, making the
+   exported model closed-vocabulary against the class list it was exported with.
+   That list is written beside the ONNX as a sidecar JSON.
+2. ``true_shape`` is only shape-checked by the model, so the wrapper synthesizes
+   it rather than exposing a second, information-free input.
+3. ``torch.quantile`` has no lowering, so
+   :func:`export_safe_metric_scale_head` swaps ``MetricScaleHead``'s depth
+   statistics for a sort-based equivalent during the export.
+4. xFormers memory-efficient attention uses operators the legacy ONNX tracer
+   cannot lower, so the wrapper switches those modules to their equivalent
+   scaled-dot-product attention implementation.
+
+Batch is the only axis that can be dynamic. The view count ``S`` is frozen at
+the traced value, since ``torch.triu_indices(S, S)`` and the mask transformer's
+positional tiling both need it as a Python int.
+"""
+
+import json
+import math
+import os
+from contextlib import contextmanager
+from typing import Dict, List, Optional, Sequence
+
+import onnx
+import torch
+from torch import nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d.export.utils import (
+    patch_xformers_attention_for_export,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.export.symbolic_funcs import register_symbolic_functions
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.metric_scale_head import MetricScaleHead
+
+
+# Canonical ONNX output ordering. Entries absent from a given build (no
+# objectness head, no metric-scale head) are dropped, never reordered.
+OUTPUT_ORDER = (
+    "pred_logits",
+    "pred_masks",
+    "pred_objectness",
+    "depth",
+    "depth_conf",
+    "world_points",
+    "world_points_conf",
+    "pose_enc",
+    "metric_depth",
+    "metric_points",
+    "intrinsics",
+)
+
+INPUT_NAME = "images"
+
+
+class FrozenTextEmbeddings(nn.Module):
+    """Stand-in for :class:`TextEncoder` that returns pre-encoded embeddings.
+
+    The real encoder maps a list of Python strings to L2-normalised SigLIP
+    embeddings. Once the vocabulary is fixed there is nothing left to compute,
+    so this returns the cached matrix and ignores its argument, which keeps the
+    decoder's call site (``self.text_encoder(classes)``) untouched.
+
+    Args:
+        embeddings: ``[C, D]`` L2-normalised class embeddings.
+    """
+
+    def __init__(self, embeddings: torch.Tensor):
+        super().__init__()
+        if embeddings.ndim != 2 or embeddings.shape[0] == 0:
+            raise ValueError(
+                "Frozen text embeddings must have shape [classes, channels]"
+            )
+        self.register_buffer("embeddings", embeddings)
+
+    def forward(self, classes=None) -> torch.Tensor:
+        """Return the frozen ``[C, D]`` class embeddings."""
+        del classes
+        return self.embeddings
+
+
+def depth_stats_export_safe(self, rel_depth: torch.Tensor) -> torch.Tensor:
+    """Export-safe replacement for :meth:`MetricScaleHead.depth_stats`.
+
+    Numerically identical to the original: ``torch.quantile`` defaults to
+    linear interpolation, which is what the sort/lerp below reproduces. The
+    quantile positions are constants at trace time, so this lowers to a single
+    sort plus gathers with no data-dependent shapes.
+
+    Args:
+        self: The :class:`MetricScaleHead` instance (bound at patch time).
+        rel_depth: ``[B, S, H, W, 1]`` or ``[B, S, H, W]`` relative depth.
+
+    Returns:
+        ``[B, 5]`` — (mean, std, median, p10, p90) averaged over views.
+    """
+    if rel_depth.dim() == 5:
+        rel_depth = rel_depth.squeeze(-1)
+
+    # flatten(2) rather than reshape(B, S, H * W) so the batch axis stays
+    # symbolic instead of being frozen into the graph.
+    num_pixels = int(rel_depth.shape[-2]) * int(rel_depth.shape[-1])
+    d = rel_depth.flatten(2).clamp(min=self.depth_min, max=self.depth_max)
+
+    mean = d.mean(dim=-1)
+    std = d.std(dim=-1, unbiased=False)
+
+    ordered, _ = torch.sort(d, dim=-1)
+
+    def quantile(q: float) -> torch.Tensor:
+        position = q * (num_pixels - 1)
+        low_index = int(math.floor(position))
+        high_index = int(math.ceil(position))
+        low = ordered[..., low_index]
+        if high_index == low_index:
+            return low
+        return low + (ordered[..., high_index] - low) * (position - low_index)
+
+    per_view = torch.stack(
+        [mean, std, quantile(0.5), quantile(0.1), quantile(0.9)], dim=-1,
+    )
+    return per_view.mean(dim=1)
+
+
+@contextmanager
+def export_safe_metric_scale_head():
+    """Temporarily swap ``MetricScaleHead.depth_stats`` for its traceable form.
+
+    Patched on the class rather than the instance so it also covers the head
+    reached through a wrapper, and restored unconditionally so an export
+    failure cannot leave the training path altered.
+    """
+    original = MetricScaleHead.depth_stats
+    MetricScaleHead.depth_stats = depth_stats_export_safe
+    try:
+        yield
+    finally:
+        MetricScaleHead.depth_stats = original
+
+
+def flatten_outputs(
+    panoptic_output: Dict,
+    geometry_output: Dict,
+) -> Dict[str, torch.Tensor]:
+    """Merge the model's two output dicts into one flat, ordered tensor map.
+
+    Drops everything ONNX cannot carry: the deep-supervision ``aux_outputs``
+    list, the detached ``out_queries``, and the nested ``metric_scale_params``
+    dict (its ``intrinsics`` is already promoted to a top-level key).
+
+    Args:
+        panoptic_output: First return value of ``NVPanoptix3Dv2Panoptic.forward``.
+        geometry_output: Second return value of the same call.
+
+    Returns:
+        Ordered mapping from ONNX output name to tensor, in :data:`OUTPUT_ORDER`.
+    """
+    merged = {}
+    for name in OUTPUT_ORDER:
+        value = panoptic_output.get(name)
+        if value is None:
+            value = geometry_output.get(name)
+        if isinstance(value, torch.Tensor):
+            merged[name] = value
+    return merged
+
+
+def resolve_output_names(model: nn.Module, dummy_input: torch.Tensor) -> List[str]:
+    """Determine which ONNX outputs this build produces, by running it once.
+
+    Which keys exist depends on the enabled heads (objectness, metric scale,
+    VGGT's camera/depth/point heads). Probing is more reliable than mirroring
+    that logic here, and it surfaces a broken checkpoint before the much slower
+    tracer runs.
+
+    Args:
+        model: A :class:`NVPanoptix3Dv2Panoptic` in eval mode, with its text
+            encoder already frozen.
+        dummy_input: ``[B, S, 3, H, W]`` probe tensor on the model's device.
+
+    Returns:
+        Output names in :data:`OUTPUT_ORDER`.
+    """
+    true_shape = dummy_input.new_zeros(dummy_input.shape[0], dummy_input.shape[1], 2)
+    with torch.no_grad():
+        panoptic_output, geometry_output = model(dummy_input, true_shape, None)
+    return list(flatten_outputs(panoptic_output, geometry_output).keys())
+
+
+class NVPanoptix3Dv2PanopticExportWrapper(nn.Module):
+    """Traceable single-input / flat-tuple-output view of the panoptic model.
+
+    Args:
+        model: A :class:`NVPanoptix3Dv2Panoptic` in eval mode.
+        class_embeddings: ``[C, D]`` L2-normalised embeddings for the export
+            vocabulary. Replaces the SigLIP text encoder in-place, so ``model``
+            must not be reused for open-vocabulary inference afterwards.
+        probe_input: ``[B, S, 3, H, W]`` tensor used to discover which outputs
+            this build produces. Required unless ``output_names`` is given.
+        output_names: Explicit output ordering, skipping the probe.
+
+    Raises:
+        ValueError: If neither ``probe_input`` nor ``output_names`` is given.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        class_embeddings: torch.Tensor,
+        probe_input: Optional[torch.Tensor] = None,
+        output_names: Optional[Sequence[str]] = None,
+    ):
+        super().__init__()
+        self.model = model
+        patch_xformers_attention_for_export(model)
+
+        decoder = model.panoptic_decoder
+        decoder.text_encoder = FrozenTextEmbeddings(class_embeddings)
+        # Aux predictions are a training-time signal only; suppressing them
+        # keeps the traced graph from retaining six extra head evaluations.
+        decoder.deep_supervision = False
+
+        # Probed only after the swap above: the real text encoder rejects the
+        # ``None`` vocabulary this wrapper passes.
+        if output_names is None:
+            if probe_input is None:
+                raise ValueError("Pass either probe_input or output_names")
+            output_names = resolve_output_names(model, probe_input)
+        self.output_names = list(output_names)
+        if not self.output_names:
+            raise ValueError("The model produced no exportable ONNX outputs")
+        if len(self.output_names) != len(set(self.output_names)):
+            raise ValueError("ONNX output names must be unique")
+        unknown_names = set(self.output_names).difference(OUTPUT_ORDER)
+        if unknown_names:
+            raise ValueError(
+                f"Unsupported ONNX output names: {sorted(unknown_names)}"
+            )
+
+    def forward(self, images: torch.Tensor):
+        """Run the panoptic model and return its outputs as a flat tuple.
+
+        Args:
+            images: ``[B, S, 3, H, W]`` multi-view images in ``[0, 1]``.
+
+        Returns:
+            Tuple of tensors ordered exactly as ``self.output_names``.
+        """
+        # ``true_shape`` is only shape-validated by the model, so it is
+        # synthesized here instead of becoming a second, information-free input.
+        true_shape = images.new_zeros(images.shape[0], images.shape[1], 2)
+
+        panoptic_output, geometry_output = self.model(images, true_shape, None)
+        merged = flatten_outputs(panoptic_output, geometry_output)
+        return tuple(merged[name] for name in self.output_names)
+
+
+def encode_vocabulary(pl_model, classes: List[str], categories: Optional[List[Dict]] = None) -> torch.Tensor:
+    """Pre-encode the export vocabulary and return its embedding matrix.
+
+    Args:
+        pl_model: The panoptic Lightning module.
+        classes: Class names the exported model will predict against.
+        categories: Optional category dicts aligned with ``classes``.
+
+    Returns:
+        ``[C, D]`` L2-normalised class embeddings, detached and on CPU.
+    """
+    pl_model.set_classes(
+        classes=classes,
+        categories=categories,
+    )
+    text_encoder = pl_model.model.panoptic_decoder.text_encoder
+    with torch.no_grad():
+        embeddings = text_encoder(classes)
+    return embeddings.detach().float().cpu()
+
+
+class ONNXExporter:
+    """Traces the wrapped panoptic model to ONNX.
+
+    Args:
+        opset_version: ONNX opset to export at.
+    """
+
+    def __init__(self, opset_version: int = 17):
+        self.opset_version = opset_version
+
+    def export_model(
+        self,
+        model: nn.Module,
+        onnx_file: str,
+        dummy_input: torch.Tensor,
+        input_names: List[str],
+        output_names: List[str],
+        batch_size: Optional[int] = None,
+        verbose: bool = False,
+    ) -> str:
+        """Export ``model`` to ``onnx_file``.
+
+        Args:
+            model: Wrapped, eval-mode model to trace.
+            onnx_file: Destination path for the ONNX file.
+            dummy_input: Input tensor used for tracing.
+            input_names: Names for the graph inputs.
+            output_names: Names for the graph outputs.
+            batch_size: Traced batch size. ``None`` or ``-1`` marks axis 0 of
+                every tensor dynamic.
+            verbose: Verbose exporter logging.
+
+        Returns:
+            The path written.
+        """
+        register_symbolic_functions(self.opset_version)
+
+        dynamic_axes = None
+        if batch_size in (None, -1):
+            dynamic_axes = {name: {0: "batch"} for name in list(input_names) + list(output_names)}
+
+        with torch.no_grad():
+            torch.onnx.export(
+                model,
+                dummy_input,
+                onnx_file,
+                input_names=input_names,
+                output_names=output_names,
+                export_params=True,
+                training=torch.onnx.TrainingMode.EVAL,
+                opset_version=self.opset_version,
+                do_constant_folding=False,
+                dynamic_axes=dynamic_axes,
+                # VGGT-1B exceeds protobuf's 2 GB embedded-weight limit.
+                external_data=True,
+                verbose=verbose,
+                dynamo=False,
+            )
+
+        return onnx_file
+
+    @staticmethod
+    def check_onnx(onnx_file: str) -> None:
+        """Validate an exported ONNX file.
+
+        Checked by path, not by loaded proto: this model exceeds protobuf's
+        2 GB message limit, which the in-memory form of the checker cannot take.
+
+        Args:
+            onnx_file: Path to the ONNX file.
+        """
+        onnx.checker.check_model(onnx_file)
+
+
+def write_vocabulary_sidecar(onnx_file: str, classes: List[str], categories: Optional[List[Dict]]) -> str:
+    """Record the baked vocabulary next to the ONNX file.
+
+    ``pred_logits`` channel ``i`` means ``classes[i]``, and that mapping is not
+    recoverable from the graph, so it is persisted for the deployment side.
+
+    Args:
+        onnx_file: Path to the exported ONNX file.
+        classes: Class names baked into the graph, in channel order.
+        categories: Optional category dicts aligned with ``classes``.
+
+    Returns:
+        Path to the JSON sidecar.
+    """
+    sidecar = f"{os.path.splitext(onnx_file)[0]}.classes.json"
+    with open(sidecar, "w", encoding="utf-8") as handle:
+        json.dump({"classes": classes, "categories": categories}, handle, indent=2)
+        handle.write("\n")
+    return sidecar

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/symbolic_funcs.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/symbolic_funcs.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ONNX symbolic functions for the NVPanoptix3Dv2 model.
+
+Five aten ops in the panoptic graph have no usable lowering at opset 17:
+
+* ``aten::meshgrid`` -- LoftUp's Fourier featurizer, the feature-fusion RoPE
+  grid, and VGGT's UV-grid helper.
+* ``aten::cartesian_prod`` -- the aggregator's 2D rotary embedding.
+* ``aten::_upsample_bicubic2d_aa`` -- DINOv2's positional-embedding
+  interpolation.
+* ``aten::expm1`` -- VGGT's point/depth output activation.
+* ``aten::triu_indices`` -- metric-scale baseline pairs across the fixed views.
+
+The first three are re-exported from NVPanoptix3D, whose copies emit the same
+subgraphs. The last two lowerings are local because the older exporter did not
+need them. Registration stays local, so NVPanoptix3D's two extra symbolics
+(``nvidia_msda`` and ``layer_norm_onnx``) cannot redirect an op this model never
+emits.
+"""
+
+import torch
+from torch.onnx import symbolic_helper
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d.export.symbolic_funcs import (
+    cartesian_prod_onnx,
+    meshgrid_onnx,
+    upsample_bicubic2d_aa,
+)
+
+__all__ = [
+    "cartesian_prod_onnx",
+    "expm1_onnx",
+    "meshgrid_onnx",
+    "triu_indices_onnx",
+    "upsample_bicubic2d_aa",
+    "register_symbolic_functions",
+]
+
+
+def expm1_onnx(g, input_tensor):
+    """Lower ``aten::expm1(x)`` to the equivalent ``Exp(x) - 1`` graph.
+
+    ONNX opset 17 has no Expm1 operator. ``CastLike`` keeps the scalar one in
+    the input dtype, which avoids invalid mixed-dtype subtraction for fp16 and
+    bf16 exports.
+
+    Args:
+        g: ONNX graph object used for constructing nodes.
+        input_tensor: Input tensor to exponentiate.
+
+    Returns:
+        ONNX ``Sub(Exp(input_tensor), CastLike(1, input_tensor))`` node.
+    """
+    one = g.op("Constant", value_t=torch.tensor(1.0, dtype=torch.float32))
+    one = g.op("CastLike", one, input_tensor)
+    return g.op("Sub", g.op("Exp", input_tensor), one)
+
+
+def triu_indices_onnx(
+    g,
+    row,
+    col,
+    offset=0,
+    dtype=None,
+    layout=None,
+    device=None,
+    pin_memory=None,
+):
+    """Lower fixed-size ``aten::triu_indices`` to an ONNX constant.
+
+    The export contract freezes the number of views, so ``row``, ``col`` and
+    ``offset`` are compile-time integers. The model uses the default int64
+    output for advanced indexing; the remaining PyTorch factory arguments do
+    not affect the exported constant.
+
+    Args:
+        g: ONNX graph object used for constructing nodes.
+        row: Number of matrix rows (compile-time integer).
+        col: Number of matrix columns (compile-time integer).
+        offset: Diagonal offset (compile-time integer).
+        dtype: PyTorch factory dtype; the model leaves it at int64.
+        layout: Unused PyTorch factory layout argument.
+        device: Unused PyTorch factory device argument.
+        pin_memory: Unused PyTorch factory pin-memory argument.
+
+    Returns:
+        Constant int64 tensor with shape ``[2, N]``.
+    """
+    del dtype, layout, device, pin_memory
+    row_value = symbolic_helper._parse_arg(row, "i")
+    col_value = symbolic_helper._parse_arg(col, "i")
+    offset_value = symbolic_helper._parse_arg(offset, "i")
+    indices = torch.triu_indices(
+        int(row_value),
+        int(col_value),
+        offset=int(offset_value),
+        dtype=torch.long,
+        device="cpu",
+    )
+    return g.op("Constant", value_t=indices)
+
+
+def register_symbolic_functions(opset_version: int) -> None:
+    """Register every NVPanoptix3Dv2 symbolic for ``opset_version``.
+
+    Args:
+        opset_version: Opset the ONNX graph is being exported at.
+    """
+    from torch.onnx import register_custom_op_symbolic
+
+    register_custom_op_symbolic("aten::meshgrid", meshgrid_onnx, opset_version)
+    register_custom_op_symbolic("aten::cartesian_prod", cartesian_prod_onnx, opset_version)
+    register_custom_op_symbolic("aten::_upsample_bicubic2d_aa", upsample_bicubic2d_aa, opset_version)
+    register_custom_op_symbolic("aten::expm1", expm1_onnx, opset_version)
+    register_custom_op_symbolic("aten::triu_indices", triu_indices_onnx, opset_version)

--- a/tests/cv_unit_test/nvpanoptix3d_v2/__init__.py
+++ b/tests/cv_unit_test/nvpanoptix3d_v2/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 unit tests."""

--- a/tests/cv_unit_test/nvpanoptix3d_v2/test_config.py
+++ b/tests/cv_unit_test/nvpanoptix3d_v2/test_config.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the NVPanoptix3Dv2 config schema and shipped specs."""
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+import nvidia_tao_pytorch.cv.nvpanoptix3d_v2 as nvpanoptix3d_v2_pkg
+from nvidia_tao_pytorch.config.nvpanoptix3d_v2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.config.nvpanoptix3d_v2.model import NVPanoptix3Dv2ModelConfig
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.build_pl_model import (
+    PANOPTIC,
+    REASONING,
+    SUPPORTED_MODEL_TYPES,
+    get_pl_module,
+)
+
+
+SPEC_DIR = Path(nvpanoptix3d_v2_pkg.__file__).parent / "experiment_specs"
+
+
+@pytest.fixture
+def experiment_spec():
+    """Return the default structured experiment config."""
+    return OmegaConf.structured(ExperimentConfig())
+
+
+@pytest.mark.cv_unit
+def test_experiment_config_instantiates(experiment_spec):
+    """The full schema must build with the expected defaults."""
+    assert experiment_spec.model.model_type == PANOPTIC
+    assert experiment_spec.model.backbone.metric_depth_head.predict_shift is True
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    "spec_name,model_type",
+    (
+        ("spec_panoptic.yaml", PANOPTIC),
+        ("spec_reasoning.yaml", REASONING),
+    ),
+)
+def test_shipped_specs_match_schema_and_format(
+    spec_name, model_type, experiment_spec
+):
+    """Each shipped spec must be well formatted and merge with the schema."""
+    spec_path = SPEC_DIR / spec_name
+    text = spec_path.read_text(encoding="utf-8")
+    spec = OmegaConf.load(spec_path)
+    merged = OmegaConf.merge(experiment_spec, spec)
+
+    assert all(line.strip() for line in text.splitlines())
+    assert "nvpanoptix3dv2" not in text
+    assert "nvpanoptix3d_v2" in text
+    assert merged.model.model_type == model_type
+
+
+@pytest.mark.cv_unit
+def test_console_entrypoint_uses_the_package_name():
+    """The installed CLI and import target must use the same package name."""
+    repo_root = SPEC_DIR.parents[3]
+    setup_text = (repo_root / "setup.py").read_text(encoding="utf-8")
+    target = (
+        "nvpanoptix3d_v2="
+        "nvidia_tao_pytorch.cv.nvpanoptix3d_v2.entrypoint.nvpanoptix3d_v2:main"
+    )
+
+    assert target in setup_text
+    assert (SPEC_DIR.parent / "entrypoint" / "nvpanoptix3d_v2.py").is_file()
+
+
+@pytest.mark.cv_unit
+def test_specs_keep_the_streamlined_public_contract():
+    """Specs should contain required overrides, not schema defaults."""
+    panoptic = OmegaConf.load(SPEC_DIR / "spec_panoptic.yaml")
+    reasoning = OmegaConf.load(SPEC_DIR / "spec_reasoning.yaml")
+    panoptic_data = panoptic.dataset.panoptic
+    reasoning_data = reasoning.dataset.reasoning
+
+    assert panoptic_data.train_preprocessed_root.endswith("/pre_scannetpp_v2")
+    assert panoptic_data.val_preprocessed_root.endswith("/pre_scannetpp_v2_val")
+    assert not {
+        "num_workers",
+        "train_num_workers",
+        "val_num_workers",
+        "train_pairs_root",
+        "val_pairs_root",
+    }.intersection(panoptic_data)
+    assert "type" not in panoptic.model.panoptic.upscaler
+
+    assert not {
+        "num_workers",
+        "val_num_workers",
+        "depth_scale",
+    }.intersection(reasoning_data)
+    assert "predict_shift" not in reasoning.model.backbone.metric_depth_head
+
+    for spec in (panoptic, reasoning):
+        assert spec.results_dir
+        assert "results_dir" not in spec.train
+        assert "wandb" not in spec
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    "spec_name,monitor",
+    (
+        ("spec_panoptic.yaml", "val/mAP"),
+        ("spec_reasoning.yaml", "val/mIoU"),
+    ),
+)
+def test_specs_use_the_common_tao_checkpointer(spec_name, monitor):
+    """Both variants configure metric-best retention through TAO's API."""
+    checkpointer = OmegaConf.load(SPEC_DIR / spec_name).train.checkpointer
+
+    assert checkpointer.enable_topk is True
+    assert checkpointer.monitor == monitor
+    assert OmegaConf.select(checkpointer, "mode") is None
+    assert checkpointer.save_top_k == 2
+
+
+@pytest.mark.cv_unit
+def test_spec_component_shapes_are_compatible():
+    """Catch config combinations that would fail at the first model forward."""
+    panoptic = OmegaConf.load(SPEC_DIR / "spec_panoptic.yaml")
+    reasoning = OmegaConf.load(SPEC_DIR / "spec_reasoning.yaml")
+    model = panoptic.model
+    fusion = model.panoptic.feature_fusion
+    decoder = model.panoptic.panoptic_decoder
+    upscaler = model.panoptic.upscaler
+
+    assert model.patch_size == upscaler.patch_size
+    assert model.embed_dim == fusion.dino_dim
+    assert fusion.hidden_dim == decoder.hidden_dim == upscaler.input_dim
+    assert decoder.mask_dim == upscaler.dim
+    assert all(
+        height % model.patch_size == 0 and width % model.patch_size == 0
+        for height, width in panoptic.dataset.panoptic.resolution
+    )
+    assert panoptic.export.input_height % model.patch_size == 0
+    assert panoptic.export.input_width % model.patch_size == 0
+
+    height, width = reasoning.dataset.reasoning.resolution
+    assert height % reasoning.model.patch_size == 0
+    assert width % reasoning.model.patch_size == 0
+    context_views = reasoning.model.backbone.metric_depth_head.metric_context_views
+    assert context_views <= reasoning.dataset.reasoning.num_views
+
+
+@pytest.mark.cv_unit
+def test_model_type_contract(experiment_spec):
+    """The schema and builder must agree on the supported variants."""
+    field = NVPanoptix3Dv2ModelConfig.__dataclass_fields__["model_type"]
+    assert set(field.metadata["valid_options"].split(",")) == set(
+        SUPPORTED_MODEL_TYPES
+    )
+
+    experiment_spec.model.model_type = "not-a-variant"
+    with pytest.raises(ValueError, match="Unsupported model.model_type"):
+        get_pl_module(experiment_spec)

--- a/tests/cv_unit_test/nvpanoptix3d_v2/test_dataloader.py
+++ b/tests/cv_unit_test/nvpanoptix3d_v2/test_dataloader.py
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for NVPanoptix3Dv2 dataloaders."""
+
+import json
+import random
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic import (
+    augmentations,
+    pl_data_module as panoptic_data_module,
+    scannetpp,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.augmentations import (
+    GeometrySafePhotometricAugmentation,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.pl_data_module import (
+    NVPanoptix3Dv2PanopticDataModule,
+    resolve_panoptic_paths,
+    resolve_vocabulary,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.scannetpp import (
+    ScanNetppCollator,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.reasoning import (
+    pl_data_module as reasoning_data_module,
+    reasoning_dataset,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.reasoning.pl_data_module import (
+    NVPanoptix3Dv2ReasoningDataModule,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.reasoning.reasoning_dataset import (
+    ReasoningSegDataset,
+    resolve_manifest_path,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.utils import (
+    center_crop_and_resize,
+    get_config_value,
+    normalize_resolution_arg,
+    rgb2id,
+)
+
+
+class _TinyDataset(Dataset):
+    """One-record dataset used to inspect DataLoader settings."""
+
+    classes = ["chair"]
+    categories = [{"id": 0, "name": "chair", "isthing": True}]
+
+    def __len__(self):
+        """Return one synthetic record."""
+        return 1
+
+    def __getitem__(self, index):
+        """Return the requested index."""
+        return index
+
+
+def _make_panoptic_roots(tmp_path):
+    """Create the minimum valid ScanNet++ preprocessed roots."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    roots = {}
+    for split, directory in (
+        ("train", "pre_scannetpp_v2"),
+        ("val", "pre_scannetpp_v2_val"),
+    ):
+        root = tmp_path / directory
+        root.mkdir()
+        (root / "all_metadata.npz").touch()
+        (root / "categories.json").write_text("[]", encoding="utf-8")
+        roots[split] = root
+    return roots
+
+
+def _load_manifest(tmp_path, records):
+    """Write and load a reasoning manifest without image decoding."""
+    manifest = tmp_path / "reasoning.jsonl"
+    manifest.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    dataset = object.__new__(ReasoningSegDataset)
+    dataset.require_seg_token = True
+    dataset.depth_scale = 1000.0
+    return dataset.load_manifest(str(manifest))
+
+
+@pytest.mark.cv_unit
+def test_variants_reuse_shared_helpers():
+    """Panoptic and reasoning must not duplicate dataloader utilities."""
+    for consumer in (scannetpp, reasoning_dataset):
+        assert consumer.center_crop_and_resize is center_crop_and_resize
+        assert consumer.normalize_resolution_arg is normalize_resolution_arg
+        assert consumer.rgb2id is rgb2id
+    assert augmentations.get_config_value is get_config_value
+    assert reasoning_data_module.get_config_value is get_config_value
+
+
+@pytest.mark.cv_unit
+def test_shared_image_utilities():
+    """Shared helpers decode IDs and keep transformed modalities aligned."""
+    encoded = np.asarray([[[3, 2, 1], [255, 255, 255]]], dtype=np.uint8)
+    np.testing.assert_array_equal(rgb2id(encoded), [[66051, 16777215]])
+    assert normalize_resolution_arg((8, 8)) == [(8, 8)]
+    assert normalize_resolution_arg([[8, 8], [8, 6]]) == [(8, 8), (8, 6)]
+
+    image = Image.fromarray(np.zeros((4, 6, 3), dtype=np.uint8))
+    depth = np.arange(24, dtype=np.float32).reshape(4, 6)
+    panoptic = np.arange(24, dtype=np.int32).reshape(4, 6)
+    intrinsics = np.asarray(
+        [[6.0, 0.0, 3.0], [0.0, 6.0, 2.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+    output = center_crop_and_resize(
+        image,
+        intrinsics,
+        depth,
+        panoptic,
+        (8, 8),
+    )
+    output_image, output_intrinsics, output_depth, output_panoptic = output
+
+    assert output_image.size == (8, 8)
+    assert output_intrinsics is intrinsics
+    assert output_depth.shape == output_panoptic.shape == (8, 8)
+    assert output_depth.dtype == np.float32
+    assert output_panoptic.dtype == np.int32
+
+
+@pytest.mark.cv_unit
+def test_photometric_augmentation():
+    """Augmentation is optional, deterministic, and geometry preserving."""
+    assert GeometrySafePhotometricAugmentation.from_config(None) is None
+    config = {
+        "enabled": True,
+        "color_jitter_prob": 1.0,
+        "gamma_exposure_prob": 1.0,
+        "grayscale_prob": 1.0,
+    }
+    augmentation = GeometrySafePhotometricAugmentation.from_config(config)
+    recipe = augmentation.sample(random.Random(17))
+    assert recipe == augmentation.sample(random.Random(17))
+
+    image = Image.fromarray(
+        np.arange(4 * 6 * 3, dtype=np.uint8).reshape(4, 6, 3)
+    )
+    first = augmentation.apply(image, recipe)
+    second = augmentation.apply(image, recipe)
+    assert first.size == image.size
+    np.testing.assert_array_equal(np.asarray(first), np.asarray(second))
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    "config,error",
+    (
+        ({"brightness": -0.1}, "brightness must be non-negative"),
+        ({"gamma": 1.0}, "gamma must be in"),
+        ({"grayscale_prob": 1.1}, "grayscale_prob must be in"),
+    ),
+)
+def test_invalid_augmentation(config, error):
+    """Invalid augmentation ranges must fail before dataset iteration."""
+    with pytest.raises(ValueError, match=error):
+        GeometrySafePhotometricAugmentation(config)
+
+
+@pytest.mark.cv_unit
+def test_panoptic_paths(tmp_path):
+    """Configured roots map directly to the two ScanNet++ splits."""
+    roots = _make_panoptic_roots(tmp_path)
+    config = SimpleNamespace(
+        train_preprocessed_root=str(roots["train"]),
+        val_preprocessed_root=str(roots["val"]),
+    )
+
+    assert resolve_panoptic_paths(config) == {
+        "train": str(roots["train"]),
+        "val": str(roots["val"]),
+    }
+
+
+@pytest.mark.cv_unit
+def test_panoptic_path_validation(tmp_path):
+    """Missing metadata and inconsistent taxonomies must fail early."""
+    train_root = tmp_path / "train"
+    val_root = tmp_path / "val"
+    train_root.mkdir()
+    val_root.mkdir()
+    config = SimpleNamespace(
+        train_preprocessed_root=str(train_root),
+        val_preprocessed_root=str(val_root),
+    )
+    with pytest.raises(FileNotFoundError, match="all_metadata.npz"):
+        resolve_panoptic_paths(config)
+
+    roots = _make_panoptic_roots(tmp_path / "valid")
+    (roots["train"] / "categories.json").write_text(
+        '[{"id": 0, "name": "chair", "isthing": true}]',
+        encoding="utf-8",
+    )
+    (roots["val"] / "categories.json").write_text(
+        '[{"id": 0, "name": "table", "isthing": true}]',
+        encoding="utf-8",
+    )
+    config = SimpleNamespace(
+        train_preprocessed_root=str(roots["train"]),
+        val_preprocessed_root=str(roots["val"]),
+    )
+    with pytest.raises(ValueError, match="same categories.json taxonomy"):
+        resolve_vocabulary(config)
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    "num_workers,timeout,persistent",
+    ((0, 0, False), (1, 600, True)),
+)
+def test_panoptic_loader_workers(
+    monkeypatch,
+    num_workers,
+    timeout,
+    persistent,
+):
+    """One worker setting must apply consistently to both splits."""
+    data_module = object.__new__(NVPanoptix3Dv2PanopticDataModule)
+    data_module.data_cfg = SimpleNamespace(
+        batch_size=1,
+        num_workers=num_workers,
+    )
+    monkeypatch.setattr(
+        data_module,
+        "build_dataset",
+        lambda split: _TinyDataset(),
+    )
+
+    for split, shuffle in (("train", True), ("val", False)):
+        loader = data_module.common_dataloader(split, shuffle)
+        assert loader.num_workers == num_workers
+        assert loader.timeout == timeout
+        assert loader.persistent_workers is persistent
+
+
+@pytest.mark.cv_unit
+def test_panoptic_validation_split(monkeypatch, tmp_path):
+    """Validation uses its configured root, both cameras, and the train seed."""
+    captured = {}
+
+    def fake_dataset(**kwargs):
+        captured.update(kwargs)
+        return _TinyDataset()
+
+    monkeypatch.setattr(
+        panoptic_data_module,
+        "ScanNetppDataset",
+        fake_dataset,
+    )
+    roots = _make_panoptic_roots(tmp_path)
+    data_module = object.__new__(NVPanoptix3Dv2PanopticDataModule)
+    data_module.data_cfg = SimpleNamespace(
+        train_preprocessed_root=str(roots["train"]),
+        val_preprocessed_root=str(roots["val"]),
+        resolution=[[518, 518]],
+        num_views=5,
+        pairs_per_scene=1,
+        randomize_view_order=True,
+        photometric_augmentation=object(),
+    )
+    data_module.seed = 17
+
+    data_module.build_dataset("val")
+
+    assert captured["preprocessed_root"] == str(roots["val"])
+    assert captured["split"] == "val"
+    assert captured["seed"] == 17
+    assert captured["photometric_augmentation"] is None
+    assert "camera_filter" not in captured
+    assert "pairs_root" not in captured
+
+
+@pytest.mark.cv_unit
+def test_panoptic_collator_vocabulary():
+    """ScanNet++ batches carry only their native class vocabulary."""
+    sample = [[{"img": torch.zeros(3, 2, 2), "dataset": "ScanNet++"}]]
+    collated = ScanNetppCollator(["chair"])(sample)
+
+    assert collated[0]["vocab"] == ["chair"]
+    assert "vocab_ignore" not in collated[0]
+
+
+@pytest.mark.cv_unit
+def test_reasoning_manifest_contract(tmp_path):
+    """Manifest assets remain portable and answers are not rewritten."""
+    manifest_dir = str(tmp_path / "reasoning")
+    assert resolve_manifest_path("scene/v0.jpg", manifest_dir) == str(
+        tmp_path / "reasoning" / "scene" / "v0.jpg"
+    )
+    assert resolve_manifest_path("/data/scene/v0.jpg", manifest_dir) == (
+        "/data/scene/v0.jpg"
+    )
+    records = [
+        {
+            "images": ["scene/v0.jpg"],
+            "depth": ["scene/v0_depth.png"],
+            "instruction": "Segment the chair.",
+            "answer": "Original [SEG] answer.",
+            "target_inst_id": 1,
+            "depth_scale": 500.0,
+        },
+        {
+            "images": ["scene/v1.jpg"],
+            "instruction": "Describe the room.",
+            "answer": "Original text-only answer.",
+            "target_inst_id": 0,
+        },
+    ]
+
+    loaded = _load_manifest(tmp_path, records)
+
+    assert [record["answer"] for record in loaded] == [
+        "Original [SEG] answer.",
+        "Original text-only answer.",
+    ]
+    assert loaded[0]["depth"] == [str(tmp_path / "scene" / "v0_depth.png")]
+    assert loaded[1]["depth"] == [None]
+    assert [record["_depth_scale"] for record in loaded] == [500.0, 1000.0]
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize("num_workers", (None, 3))
+def test_reasoning_loader_workers(monkeypatch, num_workers):
+    """The reasoning loader uses one worker setting for train and validation."""
+    captured = []
+
+    def fake_dataset(**kwargs):
+        captured.append(kwargs)
+        return _TinyDataset()
+
+    monkeypatch.setattr(
+        reasoning_data_module,
+        "ReasoningSegDataset",
+        fake_dataset,
+    )
+    values = {
+        "train_manifest": "train.jsonl",
+        "val_manifest": "val.jsonl",
+    }
+    if num_workers is not None:
+        values["num_workers"] = num_workers
+    data_module = NVPanoptix3Dv2ReasoningDataModule(
+        SimpleNamespace(**values)
+    )
+    expected = 4 if num_workers is None else num_workers
+
+    assert data_module.train_dataloader().num_workers == expected
+    assert data_module.val_dataloader().num_workers == expected
+    assert captured[0]["num_views"] == 5
+    assert captured[0]["depth_scale"] == 1000.0
+    assert captured[0]["require_seg_token"] is True
+
+
+@pytest.mark.cv_unit
+def test_reasoning_manifest_required(monkeypatch):
+    """Reasoning cannot silently fall back to a directory-style dataset."""
+    monkeypatch.setattr(
+        reasoning_data_module,
+        "ReasoningSegDataset",
+        lambda **kwargs: _TinyDataset(),
+    )
+
+    with pytest.raises(ValueError, match="train_manifest is required"):
+        NVPanoptix3Dv2ReasoningDataModule(
+            SimpleNamespace(train_manifest=None)
+        )

--- a/tests/cv_unit_test/nvpanoptix3d_v2/test_export.py
+++ b/tests/cv_unit_test/nvpanoptix3d_v2/test_export.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for NVPanoptix3Dv2 ONNX export helpers."""
+
+import json
+
+import onnx
+import pytest
+import torch
+from torch import nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.attention import (
+    Attention,
+    MemEffAttention,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.export.onnx_exporter import (
+    FrozenTextEmbeddings,
+    NVPanoptix3Dv2PanopticExportWrapper,
+    depth_stats_export_safe,
+    export_safe_metric_scale_head,
+    flatten_outputs,
+    patch_xformers_attention_for_export,
+    write_vocabulary_sidecar,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.export.symbolic_funcs import (
+    register_symbolic_functions,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.metric_scale_head import (
+    MetricScaleHead,
+)
+
+
+BATCH = 2
+VIEWS = 3
+HW = 8
+
+
+class _Expm1Model(nn.Module):
+    """Minimal graph exercising the unsupported aten::expm1 operation."""
+
+    def forward(self, value):
+        """Apply the activation that requires the custom symbolic."""
+        return torch.expm1(value)
+
+
+class _TriuIndicesModel(nn.Module):
+    """Minimal graph exercising the triangular index factory."""
+
+    def forward(self, value):
+        """Gather strict upper-triangular values using traced indices."""
+        row, col = torch.triu_indices(
+            value.shape[0],
+            value.shape[1],
+            offset=1,
+            device=value.device,
+        )
+        return value[row, col]
+
+
+class _FakeDecoder(nn.Module):
+    """Provide the decoder attributes modified for export."""
+
+    def __init__(self):
+        super().__init__()
+        self.text_encoder = None
+        self.deep_supervision = True
+
+
+class _FakePanopticModel(nn.Module):
+    """Provide the panoptic forward contract expected by the wrapper."""
+
+    def __init__(self, with_objectness=False):
+        super().__init__()
+        self.panoptic_decoder = _FakeDecoder()
+        self.with_objectness = with_objectness
+        self.seen_classes = "unset"
+
+    def forward(self, images, true_shape, classes):
+        """Return representative panoptic and geometry outputs."""
+        self.seen_classes = classes
+        self.seen_true_shape = true_shape
+        batch = images.shape[0]
+        panoptic = {
+            "pred_logits": torch.zeros(batch, 4, 5),
+            "pred_masks": torch.zeros(batch, VIEWS, 4, HW, HW),
+            "aux_outputs": [{"pred_logits": torch.zeros(batch, 4, 5)}],
+            "out_queries": torch.zeros(batch, 4, 8),
+        }
+        if self.with_objectness:
+            panoptic["pred_objectness"] = torch.zeros(batch, 4)
+        geometry = {
+            "depth": torch.zeros(batch, VIEWS, HW, HW, 1),
+            "intrinsics": torch.zeros(batch, VIEWS, 3, 3),
+            "metric_scale_params": {"scale": torch.ones(batch, 1)},
+        }
+        return panoptic, geometry
+
+
+def _depth(depth_rank=5, seed=0):
+    """Return positive, non-degenerate relative depth."""
+    generator = torch.Generator().manual_seed(seed)
+    depth = torch.rand(
+        BATCH, VIEWS, HW, HW, 1, generator=generator
+    ) * 4.0 + 0.25
+    return depth if depth_rank == 5 else depth.squeeze(-1)
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize("depth_rank", (4, 5))
+def test_export_safe_depth_stats_matches_training(depth_rank):
+    """The ONNX-safe implementation must preserve depth statistics."""
+    head = MetricScaleHead(scene_token_dim=8, hidden_dims=(8, 4))
+    depth = _depth(depth_rank)
+
+    assert torch.allclose(
+        head.depth_stats(depth),
+        depth_stats_export_safe(head, depth),
+        atol=1e-6,
+    )
+
+
+@pytest.mark.cv_unit
+def test_export_safe_depth_stats_respects_clamp_range():
+    """Both implementations must apply the configured depth bounds."""
+    head = MetricScaleHead(
+        scene_token_dim=8,
+        hidden_dims=(8, 4),
+        depth_min=1.0,
+        depth_max=2.0,
+    )
+    depth = _depth() * 100.0
+
+    assert torch.allclose(
+        head.depth_stats(depth),
+        depth_stats_export_safe(head, depth),
+        atol=1e-6,
+    )
+
+
+@pytest.mark.cv_unit
+def test_export_safe_context_restores_after_failure():
+    """A failed export must restore the training implementation."""
+    original = MetricScaleHead.depth_stats
+
+    with pytest.raises(RuntimeError, match="export failed"):
+        with export_safe_metric_scale_head():
+            assert MetricScaleHead.depth_stats is depth_stats_export_safe
+            raise RuntimeError("export failed")
+
+    assert MetricScaleHead.depth_stats is original
+
+
+@pytest.mark.cv_unit
+def test_flatten_outputs_filters_and_orders_tensors():
+    """Only supported tensors cross the ONNX boundary, in canonical order."""
+    panoptic = {
+        "pred_masks": torch.zeros(1),
+        "aux_outputs": [{"pred_logits": torch.zeros(1)}],
+        "out_queries": torch.zeros(1),
+        "pred_logits": torch.zeros(1),
+    }
+    geometry = {
+        "metric_scale_params": {"scale": torch.ones(1)},
+        "pose_enc": torch.zeros(1),
+        "depth": torch.zeros(1),
+    }
+
+    assert list(flatten_outputs(panoptic, geometry)) == [
+        "pred_logits",
+        "pred_masks",
+        "depth",
+        "pose_enc",
+    ]
+
+
+@pytest.mark.cv_unit
+def test_frozen_text_embeddings_are_exportable():
+    """Frozen vocabulary embeddings ignore input and remain model state."""
+    embeddings = torch.randn(5, 16)
+    frozen = FrozenTextEmbeddings(embeddings)
+
+    assert torch.equal(frozen(None), embeddings)
+    assert torch.equal(frozen(["ignored"]), embeddings)
+    assert "embeddings" in frozen.state_dict()
+
+
+@pytest.mark.cv_unit
+def test_export_uses_the_shared_xformers_patch():
+    """The legacy ONNX tracer must not receive xFormers operators."""
+    from nvidia_tao_pytorch.cv.nvpanoptix3d.export.utils import (
+        patch_xformers_attention_for_export as shared_patch,
+    )
+
+    assert patch_xformers_attention_for_export is shared_patch
+    model = nn.Sequential(MemEffAttention(dim=8, num_heads=2))
+    attention = model[0]
+
+    patch_xformers_attention_for_export(model)
+
+    assert attention.forward.__func__ is Attention.forward
+
+
+@pytest.mark.cv_unit
+def test_wrapper_freezes_and_flattens_the_model():
+    """The wrapper disables training paths and exposes a flat tensor tuple."""
+    model = _FakePanopticModel()
+    images = torch.zeros(BATCH, VIEWS, 3, HW, HW)
+    wrapper = NVPanoptix3Dv2PanopticExportWrapper(
+        model,
+        torch.randn(5, 16),
+        probe_input=images,
+    )
+    outputs = wrapper(images)
+
+    assert isinstance(model.panoptic_decoder.text_encoder, FrozenTextEmbeddings)
+    assert model.panoptic_decoder.deep_supervision is False
+    assert wrapper.output_names == [
+        "pred_logits",
+        "pred_masks",
+        "depth",
+        "intrinsics",
+    ]
+    assert isinstance(outputs, tuple)
+    assert len(outputs) == len(wrapper.output_names)
+    assert all(isinstance(value, torch.Tensor) for value in outputs)
+    assert model.seen_true_shape.shape == (BATCH, VIEWS, 2)
+    assert model.seen_classes is None
+
+
+@pytest.mark.cv_unit
+def test_wrapper_accepts_explicit_output_names_without_probing():
+    """Explicit names allow construction without a probe forward."""
+    model = _FakePanopticModel()
+    wrapper = NVPanoptix3Dv2PanopticExportWrapper(
+        model,
+        torch.randn(5, 16),
+        output_names=["pred_logits"],
+    )
+
+    assert wrapper.output_names == ["pred_logits"]
+    assert model.seen_classes == "unset"
+
+
+@pytest.mark.cv_unit
+def test_wrapper_requires_probe_or_output_names():
+    """The wrapper needs one way to determine its output signature."""
+    with pytest.raises(ValueError, match="probe_input or output_names"):
+        NVPanoptix3Dv2PanopticExportWrapper(
+            _FakePanopticModel(),
+            torch.randn(5, 16),
+        )
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    "categories",
+    (
+        None,
+        [
+            {"name": "wall", "id": 0},
+            {"name": "floor", "id": 1},
+            {"name": "chair", "id": 2},
+        ],
+    ),
+)
+def test_write_vocabulary_sidecar_records_channel_order(tmp_path, categories):
+    """The sidecar records the class-channel order and optional metadata."""
+    classes = ["wall", "floor", "chair"]
+    sidecar = write_vocabulary_sidecar(
+        str(tmp_path / "model.onnx"),
+        classes,
+        categories,
+    )
+
+    assert sidecar == str(tmp_path / "model.classes.json")
+    with open(sidecar, "r", encoding="utf-8") as handle:
+        assert json.load(handle) == {
+            "classes": classes,
+            "categories": categories,
+        }
+
+
+@pytest.mark.cv_unit
+def test_expm1_symbolic_lowers_to_standard_onnx_ops(tmp_path):
+    """VGGT's Expm1 activation must not remain as an aten operation."""
+    register_symbolic_functions(17)
+    output = tmp_path / "expm1.onnx"
+
+    torch.onnx.export(
+        _Expm1Model(),
+        torch.tensor([-1.0, 0.0, 1.0]),
+        str(output),
+        opset_version=17,
+        dynamo=False,
+    )
+
+    graph = onnx.load(str(output)).graph
+    op_types = [node.op_type for node in graph.node]
+    assert {"Exp", "CastLike", "Sub"} <= set(op_types)
+
+
+@pytest.mark.cv_unit
+def test_triu_indices_symbolic_lowers_to_constant(tmp_path):
+    """Fixed view-pair indices must be embedded without aten operations."""
+    register_symbolic_functions(17)
+    output = tmp_path / "triu_indices.onnx"
+
+    torch.onnx.export(
+        _TriuIndicesModel(),
+        torch.arange(25, dtype=torch.float32).reshape(5, 5),
+        str(output),
+        opset_version=17,
+        dynamo=False,
+    )
+
+    model = onnx.load(str(output))
+    onnx.checker.check_model(model)
+    assert all(node.domain != "aten" for node in model.graph.node)

--- a/tests/cv_unit_test/nvpanoptix3d_v2/test_model.py
+++ b/tests/cv_unit_test/nvpanoptix3d_v2/test_model.py
@@ -1,0 +1,632 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for NVPanoptix3Dv2 model components."""
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.metric_scale_head import (
+    MetricScaleHead,
+    apply_metric_scale,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic import (
+    feature_fusion,
+    loftup,
+    mask_transformer,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic.panoptic_model import (
+    NVPanoptix3Dv2Panoptic,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning.qwen_vlm import (
+    bind_seg_to_views,
+    extract_seg_hidden,
+    find_answer_start,
+    resolve_model_source,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning.reasoning_model import (
+    NVPanoptix3Dv2Reasoning,
+    SegToSAMPromptProjector,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models import (
+    aggregator,
+    vggt,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.vggt.models.patch_embed import (
+    PatchEmbed,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.metric_depth import (
+    MetricDepthLoss,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.criterion import (
+    masked_dice_loss,
+    masked_sigmoid_ce_loss,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.engine_eval import (
+    panoptic_inference,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.losses import (
+    NVPanoptix3Dv2PanopticLoss,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.panoptic.mAP import (
+    evaluate_instance_map_segvggt,
+    prepare_instance_map_sample,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.reasoning.losses import (
+    NVPanoptix3Dv2ReasoningLoss,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.utils.reasoning.score import (
+    CanonicalPointCloudMetrics,
+    score_batch_on_canonical_points,
+)
+
+
+BATCH = 2
+VIEWS = 4
+PATCHES = 6
+TOKEN_DIM = 8
+HW = 8
+
+
+class _Backbone(nn.Module):
+    """Small VGGT stand-in exposing the tensors used by the model."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+
+    def forward(self, images):
+        """Return deterministic geometry and feature tensors."""
+        batch, views, _, height, width = images.shape
+        return {
+            "dino_feats": torch.ones(batch, views, 2, 3),
+            "vggt_feats": torch.ones(batch, views, 2, 4),
+            "depth": torch.ones(batch, views, height, width, 1),
+            "depth_conf": torch.ones(batch, views, height, width),
+            "world_points": torch.ones(batch, views, height, width, 3),
+            "world_points_conf": torch.ones(batch, views, height, width),
+            "pose_enc": torch.zeros(batch, views, 9),
+        }
+
+
+class _Decoder(nn.Module):
+    """Record the model-to-decoder contract."""
+
+    def forward(
+        self,
+        dino_feats,
+        vggt_feats,
+        images,
+        classes,
+        outdevice=None,
+    ):
+        """Return representative panoptic outputs."""
+        self.call = (dino_feats, vggt_feats, images, classes, outdevice)
+        batch, views = images.shape[:2]
+        return {
+            "pred_logits": images.new_zeros(
+                (batch, 2, len(classes))
+            ),
+            "pred_masks": images.new_zeros((batch, views, 2, 2, 2)),
+        }
+
+
+class _MetricHead(nn.Module):
+    """Return a deterministic scene scale and intrinsics."""
+
+    def forward(
+        self,
+        vggt_feats,
+        rel_depth,
+        pose_enc,
+        image_size_hw,
+    ):
+        """Return scale two for every scene."""
+        self.call = (vggt_feats, rel_depth, pose_enc, image_size_hw)
+        batch, views = rel_depth.shape[:2]
+        scale = rel_depth.new_full((batch, 1), 2.0)
+        return {
+            "log_s": scale.log(),
+            "scale": scale,
+            "intrinsics": torch.eye(3).expand(
+                batch, views, 3, 3
+            ).clone(),
+        }
+
+
+class _Qwen(nn.Module):
+    """Minimal language-model output contract."""
+
+    def forward(self, inputs):
+        """Return tensors supplied by the test."""
+        return SimpleNamespace(
+            lm_logits=inputs["lm_logits"],
+            labels=inputs.get("labels"),
+            hidden=inputs["hidden"],
+            input_ids=inputs["input_ids"],
+        )
+
+    @staticmethod
+    def extract_seg_hidden(output):
+        """Gather hidden states at the synthetic SEG token."""
+        return extract_seg_hidden(
+            output.hidden,
+            output.input_ids,
+            seg_token_id=9,
+        )
+
+
+class _Sam(nn.Module):
+    """Parameter-only SAM stand-in."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+
+
+def _pose_enc(batch=BATCH, views=VIEWS, seed=0):
+    """Build a plausible pose-encoding tensor."""
+    generator = torch.Generator().manual_seed(seed)
+    translation = torch.randn(
+        batch, views, 3, generator=generator
+    ) * 0.5
+    quaternion = torch.randn(batch, views, 4, generator=generator)
+    quaternion = quaternion / quaternion.norm(dim=-1, keepdim=True)
+    fov = torch.full((batch, views, 2), 0.9)
+    return torch.cat([translation, quaternion, fov], dim=-1)
+
+
+def _metric_inputs(views=VIEWS):
+    """Return small inputs accepted by MetricScaleHead."""
+    features = torch.randn(BATCH, views, PATCHES, TOKEN_DIM)
+    depth = torch.rand(BATCH, views, HW, HW, 1) + 0.5
+    return features, depth, _pose_enc(views=views), (HW, HW)
+
+
+def _metric_head(**kwargs):
+    """Build a small metric head."""
+    kwargs.setdefault("scene_token_dim", TOKEN_DIM)
+    kwargs.setdefault("hidden_dims", (8, 4))
+    return MetricScaleHead(**kwargs)
+
+
+@pytest.mark.cv_unit
+def test_panoptic_forward():
+    """The top-level model connects features and metric geometry correctly."""
+    decoder = _Decoder()
+    metric_head = _MetricHead()
+    model = NVPanoptix3Dv2Panoptic(
+        _Backbone(),
+        decoder,
+        metric_head,
+    )
+    images = torch.zeros(2, 3, 3, 4, 5)
+    true_shape = torch.tensor([[[4, 5]] * 3] * 2)
+
+    panoptic, geometry = model(
+        images,
+        true_shape,
+        ["chair", "table"],
+    )
+
+    assert panoptic["pred_logits"].shape == (2, 2, 2)
+    assert decoder.call[0].shape == (2, 3, 2, 3)
+    assert decoder.call[1].shape == (2, 3, 2, 4)
+    assert torch.equal(
+        geometry["metric_depth"],
+        2.0 * geometry["depth"],
+    )
+    assert torch.equal(
+        geometry["metric_points"],
+        2.0 * geometry["world_points"],
+    )
+    assert metric_head.call[-1] == (4, 5)
+
+
+@pytest.mark.cv_unit
+def test_panoptic_input_and_freezing():
+    """Invalid metadata fails early and freezing affects only VGGT."""
+    backbone = _Backbone()
+    decoder = nn.Linear(2, 2)
+    model = NVPanoptix3Dv2Panoptic(backbone, decoder)
+    images = torch.zeros(2, 3, 3, 4, 5)
+
+    with pytest.raises(ValueError, match="true_shape must have shape"):
+        model(images, torch.zeros(2, 2, 2), ["chair"])
+
+    model.freeze_vggt_weights()
+    assert all(
+        not parameter.requires_grad
+        for parameter in backbone.parameters()
+    )
+    assert all(
+        parameter.requires_grad
+        for parameter in decoder.parameters()
+    )
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize("predict_shift", (False, True))
+def test_metric_head_identity(predict_shift):
+    """A new metric head preserves depth in scale and shift modes."""
+    head = _metric_head(predict_shift=predict_shift)
+    features, depth, pose_enc, image_size = _metric_inputs()
+    params = head(features, depth, pose_enc, image_size)
+
+    assert params["scale"].shape == (BATCH, 1)
+    assert params["intrinsics"].shape == (BATCH, VIEWS, 3, 3)
+    assert torch.allclose(params["scale"], torch.ones_like(params["scale"]))
+    assert torch.allclose(apply_metric_scale(depth, params), depth)
+    assert ("b" in params) is predict_shift
+
+
+@pytest.mark.cv_unit
+def test_metric_head_context_and_gradients():
+    """Only the configured view prefix contributes, without VGGT gradients."""
+    head = _metric_head(metric_context_views=2)
+    torch.nn.init.normal_(head.mlp[-1].weight, std=0.1)
+    features, depth, pose_enc, image_size = _metric_inputs()
+
+    baseline = head(features, depth, pose_enc, image_size)["scale"]
+    perturbed = features.clone()
+    perturbed[:, 2:] += 10.0
+    assert torch.allclose(
+        baseline,
+        head(perturbed, depth, pose_enc, image_size)["scale"],
+    )
+
+    features.requires_grad_(True)
+    depth.requires_grad_(True)
+    head(features, depth, pose_enc, image_size)["scale"].sum().backward()
+    assert features.grad is None
+    assert depth.grad is None
+    assert head.mlp[-1].weight.grad is not None
+
+
+@pytest.mark.cv_unit
+def test_metric_head_validation():
+    """Invalid context and mismatched view counts are rejected."""
+    with pytest.raises(ValueError, match="must be positive"):
+        _metric_head(metric_context_views=0)
+
+    head = _metric_head()
+    features, depth, pose_enc, image_size = _metric_inputs()
+    with pytest.raises(ValueError, match="view counts must match"):
+        head(features, depth[:, :-1], pose_enc, image_size)
+    with pytest.raises(ValueError, match="must be 4D or 5D"):
+        apply_metric_scale(
+            torch.ones(BATCH, VIEWS, HW),
+            {"scale": torch.ones(BATCH, 1)},
+        )
+
+
+@pytest.mark.cv_unit
+def test_panoptic_loss_contract():
+    """Public loss weights drive matching and invalid pixels are ignored."""
+    loss = NVPanoptix3Dv2PanopticLoss(
+        class_weight=2.5,
+        mask_weight=7.0,
+        dice_weight=3.0,
+        deep_supervision=False,
+    )
+    matcher = loss.criterion.matcher
+    assert matcher.cost_class == pytest.approx(2.5)
+    assert matcher.cost_mask == pytest.approx(7.0)
+    assert matcher.cost_dice == pytest.approx(3.0)
+
+    target = torch.tensor([[[1.0, 0.0]]])
+    valid = torch.tensor([[[1.0, 0.0]]])
+    baseline = torch.tensor([[[10.0, -10.0]]])
+    changed_void = torch.tensor([[[10.0, 10.0]]])
+    for loss_fn in (masked_sigmoid_ce_loss, masked_dice_loss):
+        assert torch.allclose(
+            loss_fn(baseline, target, valid, 1.0),
+            loss_fn(changed_void, target, valid, 1.0),
+        )
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize("gate", (None, "objectness"))
+def test_panoptic_inference(gate):
+    """Inference creates disjoint segments and honors confidence gating."""
+    kwargs = {}
+    if gate:
+        kwargs[f"{gate}_logits"] = torch.full((1, 2), -10.0)
+    result = panoptic_inference(
+        torch.tensor([[[10.0, -10.0], [-10.0, 10.0]]]),
+        torch.tensor(
+            [[[[[10.0, 10.0], [-10.0, -10.0]],
+               [[-10.0, -10.0], [10.0, 10.0]]]]]
+        ),
+        target_hw=(2, 2),
+        mask_threshold=0.5,
+        **kwargs,
+    )[0]
+
+    if gate:
+        assert not result["segments_info"]
+    else:
+        assert torch.equal(
+            result["pan"],
+            torch.tensor([[[1, 1], [2, 2]]], dtype=torch.int32),
+        )
+
+
+@pytest.mark.cv_unit
+def test_instance_map():
+    """An exactly aligned instance has perfect AP."""
+    sample = prepare_instance_map_sample(
+        np.asarray([[[1, 1, 0, 0]]]),
+        [{"id": 1, "category_id": 0, "score": 0.9}],
+        np.asarray([[[7, 7, 0, 0]]]),
+        np.asarray([[[0, 0, -1, -1]]]),
+        num_categories=2,
+        evaluated_category_ids=[0],
+        min_points=1,
+    )
+
+    assert evaluate_instance_map_segvggt([sample], [0]) == {
+        "mAP": 100.0,
+        "mAP50": 100.0,
+        "mAP25": 100.0,
+    }
+
+
+@pytest.mark.cv_unit
+def test_qwen_token_binding():
+    """SEG hidden states preserve sample order and bind to requested views."""
+    hidden = torch.arange(2 * 4 * 3).reshape(2, 4, 3)
+    token_ids = torch.tensor([[9, 2, 9, 0], [1, 9, 0, 0]])
+    selected, batch_index = extract_seg_hidden(
+        hidden,
+        token_ids,
+        seg_token_id=9,
+    )
+    with pytest.warns(RuntimeWarning, match="dropped 1"):
+        sample, view, keep = bind_seg_to_views(
+            batch_index,
+            [[1], [0]],
+            num_views=2,
+        )
+
+    assert torch.equal(
+        selected,
+        torch.stack([hidden[0, 0], hidden[0, 2], hidden[1, 1]]),
+    )
+    assert sample.tolist() == [0, 1]
+    assert view.tolist() == [1, 0]
+    assert keep.tolist() == [0, 2]
+    assert find_answer_start(
+        torch.tensor([5, 1, 2, 6, 1, 2, 7]),
+        [1, 2],
+    ) == 6
+
+
+@pytest.mark.cv_unit
+def test_qwen_model_source(tmp_path):
+    """Local Qwen sources require processor and tokenizer metadata."""
+    for name in (
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer_config.json",
+    ):
+        (tmp_path / name).touch()
+    source, is_local = resolve_model_source(str(tmp_path))
+    assert source == str(tmp_path)
+    assert is_local
+
+    with pytest.raises(FileNotFoundError, match="Check the container mount"):
+        resolve_model_source(str(tmp_path / "missing"))
+
+
+@pytest.mark.cv_unit
+def test_reasoning_projector():
+    """The projector keeps one prompt per sample and marks missing prompts."""
+    projector = SegToSAMPromptProjector(
+        d_llm=4,
+        d_sam=3,
+        hidden=5,
+    )
+    hidden = torch.randn(3, 4)
+    batch_index = torch.tensor([0, 0, 2])
+
+    prompt, valid = projector(hidden, batch_index, batch_size=4)
+    projected = projector.project_all(hidden)
+
+    assert prompt.shape == (1, 4, 3)
+    assert valid.tolist() == [True, False, True, False]
+    assert torch.allclose(prompt[0, 0], projected[0])
+    assert torch.allclose(prompt[0, 2], projected[2])
+    assert torch.allclose(prompt[0, 1], projector.null_prompt[0])
+
+
+@pytest.mark.cv_unit
+def test_reasoning_forward(monkeypatch):
+    """Each SEG prompt is sent to its requested image view."""
+    sam = _Sam()
+    model = NVPanoptix3Dv2Reasoning(
+        qwen=_Qwen(),
+        sam3_image_model=sam,
+        projector=SegToSAMPromptProjector(
+            d_llm=4,
+            d_sam=3,
+            hidden=5,
+        ),
+    )
+    captured = {}
+
+    def fake_sam_forward(images, prompt):
+        captured["images"] = images
+        captured["prompt"] = prompt
+        count = images.shape[0]
+        return {
+            "pred_masks": images.new_zeros((count, 1, 1, 1)),
+            "pred_logits": images.new_zeros((count, 1)),
+            "presence_logits": None,
+        }
+
+    monkeypatch.setattr(
+        model,
+        "sam_forward_with_prompt",
+        fake_sam_forward,
+    )
+    images = torch.arange(
+        2 * 2 * 3 * 2 * 2,
+        dtype=torch.float32,
+    ).reshape(2, 2, 3, 2, 2)
+    qwen_inputs = {
+        "hidden": torch.randn(2, 3, 4),
+        "input_ids": torch.tensor([[1, 9, 2], [9, 2, 3]]),
+        "lm_logits": torch.randn(2, 3, 5),
+        "labels": None,
+    }
+
+    output = model(
+        images,
+        qwen_inputs,
+        seg_view_indices=[[1], [0]],
+    )
+
+    assert output["seg_sample_idx"].tolist() == [0, 1]
+    assert output["seg_view_idx"].tolist() == [1, 0]
+    assert torch.equal(captured["images"], images[[0, 1], [1, 0]])
+    assert captured["prompt"].shape == (1, 2, 3)
+    assert not sam.weight.requires_grad
+
+
+@pytest.mark.cv_unit
+def test_reasoning_lift_and_loss():
+    """Reasoning lifts bound views and shares the metric-depth objective."""
+    world_points = torch.arange(
+        2 * 2 * 1 * 2 * 3,
+        dtype=torch.float32,
+    ).reshape(2, 2, 1, 2, 3)
+    pred_masks = torch.tensor(
+        [
+            [[[10.0, -10.0]], [[-10.0, 10.0]]],
+            [[[-10.0, 10.0]], [[10.0, -10.0]]],
+        ]
+    )
+    pred_logits = torch.tensor(
+        [[10.0, -10.0], [-10.0, 10.0]]
+    )
+    clouds, _, selected, _ = (
+        NVPanoptix3Dv2Reasoning.lift_bindings_to_point_clouds(
+            pred_masks,
+            pred_logits,
+            world_points,
+            torch.tensor([0, 0]),
+            torch.tensor([0, 1]),
+            batch_size=2,
+        )
+    )
+    expected = torch.stack(
+        [world_points[0, 0, 0, 0], world_points[0, 1, 0, 0]]
+    )
+    assert torch.equal(clouds[0], expected)
+    assert clouds[1].shape == (0, 3)
+    assert selected.tolist() == [0, 1]
+
+    criterion = NVPanoptix3Dv2ReasoningLoss(metric_weight=1.0)
+    gt_depth = torch.linspace(0.5, 4.0, 16).reshape(1, 1, 4, 4)
+    metric_depth = (gt_depth * 1.1).unsqueeze(-1)
+    output = {
+        "pred_masks": torch.zeros(1, 1, 4, 4),
+        "metric_depth": metric_depth,
+    }
+    assert torch.allclose(
+        criterion.metric_depth_loss(output, gt_depth),
+        MetricDepthLoss()(metric_depth, gt_depth)["loss_metric_total"],
+    )
+
+
+@pytest.mark.cv_unit
+def test_reasoning_metric():
+    """Canonical scoring uses every valid view."""
+    meter = CanonicalPointCloudMetrics()
+    output = {
+        "seg_sample_idx": torch.tensor([0]),
+        "seg_view_idx": torch.tensor([0]),
+        "pred_masks": torch.tensor([[[[10.0, -10.0]]]]),
+        "pred_logits": torch.tensor([[1.0]]),
+    }
+    panoptic = torch.tensor([[[[7, 7]], [[0, 0]]]])
+    score_batch_on_canonical_points(
+        meter,
+        output,
+        panoptic,
+        torch.tensor([7]),
+        torch.ones_like(panoptic, dtype=torch.bool),
+        0.5,
+    )
+
+    assert meter.compute() == {
+        "mIoU": pytest.approx(0.5),
+        "mAP50": pytest.approx(1.0),
+        "mAP25": pytest.approx(1.0),
+    }
+
+
+LAYER_BINDINGS = (
+    (aggregator, "Block", "layers", "block"),
+    (aggregator, "PositionGetter", "layers", "rope"),
+    (aggregator, "vit_base", "layers", "vision_transformer"),
+    (feature_fusion, "Block", "layers", "block"),
+    (feature_fusion, "RotaryPositionEmbedding2D", "layers", "rope"),
+    (vggt, "CameraHead", "heads", "camera_head"),
+    (vggt, "DPTHead", "heads", "dpt_head"),
+)
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    "consumer,name,subpackage,module",
+    LAYER_BINDINGS,
+)
+def test_shared_model_imports(consumer, name, subpackage, module):
+    """Shared VGGT objects are imported rather than copied."""
+    source = importlib.import_module(
+        "nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt."
+        f"{subpackage}.{module}"
+    )
+    assert getattr(consumer, name) is getattr(source, name)
+
+
+@pytest.mark.cv_unit
+def test_shared_model_helpers():
+    """Generic model helpers bind to their shared TAO implementations."""
+    from nvidia_tao_pytorch.cv.mask2former.model.transformer_decoder.position_encoding import (
+        PositionEmbeddingSine,
+    )
+    from nvidia_tao_pytorch.cv.nvpanoptix3d.model.transformer_decoder.joint_depth_transformer_decoder import (
+        FFNLayer,
+        MLP,
+        SelfAttentionLayer,
+    )
+    from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.mlp import Mlp
+    from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.models.aggregator import (
+        slice_expand_and_flatten,
+    )
+
+    assert mask_transformer.FFNLayer is FFNLayer
+    assert mask_transformer.MLP is MLP
+    assert mask_transformer.PositionEmbeddingSine is PositionEmbeddingSine
+    assert mask_transformer.SelfAttentionLayer is SelfAttentionLayer
+    assert loftup.Mlp is Mlp
+    assert aggregator.slice_expand_and_flatten is (
+        slice_expand_and_flatten
+    )
+
+
+@pytest.mark.cv_unit
+def test_local_patch_embed():
+    """PatchEmbed remains local because the V2 version differs."""
+    assert aggregator.PatchEmbed is PatchEmbed
+    assert PatchEmbed.__module__.startswith(
+        "nvidia_tao_pytorch.cv.nvpanoptix3d_v2"
+    )

--- a/tests/cv_unit_test/nvpanoptix3d_v2/test_trainer.py
+++ b/tests/cv_unit_test/nvpanoptix3d_v2/test_trainer.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lightning Trainer tests for both NVPanoptix3Dv2 variants."""
+
+from types import MethodType
+
+import pytest
+import pytorch_lightning as pl
+import torch
+from omegaconf import OmegaConf
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+from nvidia_tao_pytorch.config.nvpanoptix3d_v2.default_config import (
+    ExperimentConfig,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.panoptic import (
+    pl_model as panoptic_pl,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.reasoning import (
+    pl_model as reasoning_pl,
+)
+
+
+class _SingleBatchDataset(Dataset):
+    """Dataset containing one already-batched multi-view sample."""
+
+    def __init__(self, sample):
+        self.sample = sample
+
+    def __len__(self):
+        """Return one trainer batch."""
+        return 1
+
+    def __getitem__(self, index):
+        """Return the synthetic sample."""
+        del index
+        return self.sample
+
+
+def _first_sample(samples):
+    """Remove the DataLoader's outer list without recollating tensors."""
+    return samples[0]
+
+
+class _SingleBatchDataModule(pl.LightningDataModule):
+    """Expose one batch to every Lightning lifecycle."""
+
+    def __init__(self, sample):
+        super().__init__()
+        self.dataset = _SingleBatchDataset(sample)
+
+    def _loader(self):
+        """Build a fresh single-process loader."""
+        return DataLoader(
+            self.dataset,
+            batch_size=1,
+            num_workers=0,
+            collate_fn=_first_sample,
+        )
+
+    def train_dataloader(self):
+        """Return the training loader."""
+        return self._loader()
+
+    def val_dataloader(self):
+        """Return the validation loader."""
+        return self._loader()
+
+    def test_dataloader(self):
+        """Return the evaluation loader."""
+        return self._loader()
+
+    def predict_dataloader(self):
+        """Return the inference loader."""
+        return self._loader()
+
+
+class _TinyPanopticDecoder(nn.Module):
+    """Trainable decoder surface required by the optimizer."""
+
+    label_mode = "sigmoid"
+
+    def __init__(self):
+        super().__init__()
+        self.score = nn.Parameter(torch.tensor(2.0))
+
+
+class _TinyPanopticModel(nn.Module):
+    """Small differentiable replacement for VGGT and the panoptic decoder."""
+
+    def __init__(self):
+        super().__init__()
+        self.panoptic_decoder = _TinyPanopticDecoder()
+        self.metric_depth_head = None
+        self.classes = []
+
+    def freeze_vggt_weights(self):
+        """No-op because the stand-in has no backbone parameters."""
+
+    def set_vocab(self, classes, device=None):
+        """Record the configured class vocabulary."""
+        del device
+        self.classes = list(classes)
+
+    def forward(self, images, true_shape, classes):
+        """Return one confident query connected to the decoder parameter."""
+        del true_shape
+        batch, views, _, height, width = images.shape
+        class_count = len(classes or self.classes)
+        score = self.panoptic_decoder.score
+        return {
+            "pred_logits": score.expand(batch, 1, class_count),
+            "pred_masks": score.expand(
+                batch,
+                views,
+                1,
+                height,
+                width,
+            ),
+        }, {}
+
+
+class _TinyPanopticCriterion(nn.Module):
+    """Return a differentiable scalar from the fake decoder output."""
+
+    def forward(
+        self,
+        batch,
+        panoptic,
+        classes,
+        geometry_output=None,
+        gt_depth=None,
+    ):
+        """Compute the synthetic training loss."""
+        del batch, classes, geometry_output, gt_depth
+        loss = panoptic["pred_logits"].mean()
+        return loss, {"loss_total": loss.detach()}
+
+
+class _TinyReasoningModel(nn.Module):
+    """Single-parameter reasoning model used by its optimizer."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(()))
+
+
+class _UnusedCriterion(nn.Module):
+    """Criterion placeholder; forward_batch is replaced in these tests."""
+
+    def forward(self, *args, **kwargs):
+        """Fail if the trainer crosses the intended test boundary."""
+        raise AssertionError("The trainer test supplies forward_batch directly")
+
+
+def _experiment_config(tmp_path, variant):
+    """Build a minimal structured config for one trainer lifecycle."""
+    config = OmegaConf.structured(ExperimentConfig())
+    results_dir = tmp_path / variant
+    results_dir.mkdir()
+    config.results_dir = str(results_dir)
+    config.model.model_type = variant
+    config.train.num_epochs = 1
+    config.train.num_gpus = 1
+    config.train.num_nodes = 1
+    config.train.checkpointer.enable_topk = False
+    config.inference.output_dir = str(results_dir / "predictions")
+    return config
+
+
+def _trainer(root):
+    """Build a deterministic CPU trainer that executes one batch."""
+    return pl.Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=1,
+        fast_dev_run=True,
+        default_root_dir=str(root),
+        logger=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        use_distributed_sampler=False,
+    )
+
+
+def _panoptic_sample():
+    """Return one two-view panoptic trainer batch."""
+    views = []
+    for view_index in range(2):
+        view = {
+            "img": torch.zeros(1, 3, 16, 16),
+            "true_shape": torch.tensor([[16, 16]]),
+            "pan_inst_id": torch.full(
+                (1, 16, 16),
+                7,
+                dtype=torch.long,
+            ),
+            "pan_cls_id": torch.zeros(
+                1,
+                16,
+                16,
+                dtype=torch.long,
+            ),
+            "label": ["scene_000"],
+        }
+        if view_index == 0:
+            view["vocab"] = ["chair"]
+        views.append(view)
+    return views
+
+
+def _reasoning_sample():
+    """Return one reasoning trainer batch."""
+    return [
+        {
+            "img": torch.zeros(1, 3, 4, 4),
+            "pan_inst_id": torch.full(
+                (1, 4, 4),
+                7,
+                dtype=torch.long,
+            ),
+            "depthmap": torch.ones(1, 4, 4),
+            "instruction": ["Segment the chair."],
+            "target_inst_id": torch.tensor([7]),
+        }
+    ]
+
+
+def _reasoning_forward_batch(module, batch):
+    """Return differentiable loss and perfect synthetic predictions."""
+    loss = module.model.weight.square()
+    logs = {
+        "loss_total": loss.detach(),
+        "loss_text": loss.detach(),
+        "loss_mask": torch.zeros_like(loss),
+        "loss_dice": torch.zeros_like(loss),
+        "loss_score": torch.zeros_like(loss),
+        "n_mask_valid": torch.ones_like(loss),
+    }
+    height, width = batch[0]["pan_inst_id"].shape[-2:]
+    output = {
+        "seg_sample_idx": torch.tensor(
+            [0],
+            device=module.device,
+        ),
+        "seg_view_idx": torch.tensor(
+            [0],
+            device=module.device,
+        ),
+        "pred_masks": torch.full(
+            (1, 1, height, width),
+            10.0,
+            device=module.device,
+        ),
+        "pred_logits": torch.full(
+            (1, 1),
+            10.0,
+            device=module.device,
+        ),
+        "point_mask_prob": torch.ones(
+            1,
+            height,
+            width,
+            device=module.device,
+        ),
+        "segmented_point_clouds": [
+            torch.zeros(1, 3, device=module.device)
+        ],
+    }
+    return loss, logs, output
+
+
+@pytest.mark.cv_unit
+@pytest.mark.train
+@pytest.mark.evaluate
+@pytest.mark.infer
+def test_panoptic_trainer(monkeypatch, tmp_path):
+    """The panoptic module completes fit, test, and predict lifecycles."""
+    monkeypatch.setattr(
+        panoptic_pl,
+        "build_model_from_config",
+        lambda config: _TinyPanopticModel(),
+    )
+    monkeypatch.setattr(
+        panoptic_pl,
+        "build_criterion_from_config",
+        lambda config: _TinyPanopticCriterion(),
+    )
+    config = _experiment_config(tmp_path, "panoptic")
+    module = panoptic_pl.NVPanoptix3Dv2PanopticPlModule(config)
+    module.set_classes(
+        ["chair"],
+        [{"id": 0, "name": "chair", "isthing": True}],
+    )
+    data_module = _SingleBatchDataModule(_panoptic_sample())
+    initial_score = module.model.panoptic_decoder.score.detach().clone()
+
+    fit_trainer = _trainer(config.results_dir)
+    fit_trainer.fit(module, datamodule=data_module)
+    assert fit_trainer.global_step == 1
+    assert not torch.equal(
+        module.model.panoptic_decoder.score.detach(),
+        initial_score,
+    )
+
+    _trainer(config.results_dir).test(
+        module,
+        datamodule=data_module,
+    )
+    assert (tmp_path / "panoptic" / "instance_map.json").is_file()
+
+    _trainer(config.results_dir).predict(
+        module,
+        datamodule=data_module,
+    )
+    assert list(
+        (tmp_path / "panoptic" / "predictions").glob("*.npz")
+    )
+
+
+@pytest.mark.cv_unit
+@pytest.mark.train
+@pytest.mark.evaluate
+@pytest.mark.infer
+def test_reasoning_trainer(monkeypatch, tmp_path):
+    """The reasoning module completes fit, test, and predict lifecycles."""
+    monkeypatch.setattr(
+        reasoning_pl,
+        "build_reasoning_model_from_config",
+        lambda config: _TinyReasoningModel(),
+    )
+    monkeypatch.setattr(
+        reasoning_pl,
+        "build_sam_criterion",
+        lambda config: _UnusedCriterion(),
+    )
+    config = _experiment_config(tmp_path, "reasoning")
+    module = reasoning_pl.NVPanoptix3Dv2ReasoningPlModule(config)
+    module.forward_batch = MethodType(
+        _reasoning_forward_batch,
+        module,
+    )
+    data_module = _SingleBatchDataModule(_reasoning_sample())
+    initial_weight = module.model.weight.detach().clone()
+
+    fit_trainer = _trainer(config.results_dir)
+    fit_trainer.fit(module, datamodule=data_module)
+    assert fit_trainer.global_step == 1
+    assert not torch.equal(
+        module.model.weight.detach(),
+        initial_weight,
+    )
+
+    _trainer(config.results_dir).test(
+        module,
+        datamodule=data_module,
+    )
+    metrics = tmp_path / "reasoning" / "reasoning_point_cloud_metrics.json"
+    assert metrics.is_file()
+
+    _trainer(config.results_dir).predict(
+        module,
+        datamodule=data_module,
+    )
+    assert list(
+        (tmp_path / "reasoning" / "predictions").glob("*.npz")
+    )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->

Adds ONNX export support for the NVPanoptix3Dv2 panoptic variant and a focused unit-test suite covering configuration, dataloaders, model utilities, metrics, reasoning, shared imports, and export behavior.

### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->

NVPanoptix3Dv2 requires an export path that can convert its multi-view panoptic model into a deployment-ready ONNX graph. The exporter handles operations and inputs that cannot be traced directly, including:

- Freezing the text vocabulary into the exported graph.
- Writing class-channel metadata to a JSON sidecar.
- Replacing unsupported metric-depth quantile operations with an ONNX-safe equivalent.
- Replacing xFormers attention with traceable PyTorch attention.
- Registering ONNX symbolics for unsupported `expm1` and `triu_indices` operations.
- Flattening panoptic and geometry outputs into a stable tensor-only interface.
- Saving large model weights as external ONNX data.

The unit tests protect these export contracts and the existing NVPanoptix3Dv2 configuration, dataloader, model, metric, and reasoning behavior.

### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->

Part of TAOVN-1251

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->

Yes.

Previously, NVPanoptix3Dv2 did not provide an ONNX exporter. This PR allows the panoptic variant to be exported with one multi-view image input and a stable set of panoptic and geometry outputs.

The export vocabulary is fixed at export time and recorded in a companion `.classes.json` file. The number of views is fixed to the traced value, while the batch dimension can be dynamic.

This is an additive change and does not break existing training, evaluation, or inference usage. ONNX export for the reasoning variant is not included.

### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->

The complete NVPanoptix3Dv2 unit-test folder was executed in the TAO container:

```bash
cd /workspace/tao-pytorch
python -m pytest -q tests/cv_unit_test/nvpanoptix3d_v2
```

Result:

```text
114 passed, 7 warnings in 13.52s
```

The warnings are upstream deprecation and tracing warnings from timm and the legacy PyTorch ONNX exporter.

The tests cover:

- Export-safe metric-depth statistics.
- ONNX symbolic registration and graph validation.
- Frozen vocabulary embeddings and vocabulary sidecar generation.
- Export output filtering and ordering.
- Export-wrapper input and output contracts.
- xFormers attention replacement.
- Invalid export arguments and tensor shapes.
- Configuration and experiment-spec compatibility.
- Panoptic and reasoning dataloaders.
- Model, loss, metric, and post-processing behavior.
- Direct reuse of shared NVPanoptix3D and Mask2Former components.

### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

Generated-by: <tool name and version>
-->

Yes — portions were co-authored with an AI coding assistant.

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Added ONNX export support for the NVPanoptix3Dv2 panoptic model, including frozen-vocabulary metadata and export validation.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [x] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->

The main implementation is in:

- `nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/onnx_exporter.py`
- `nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/symbolic_funcs.py`

The NVPanoptix3D exporter changes only move the xFormers attention patch into a shared utility; its export behavior is unchanged.