### PR TITLE
[TAOVN-1251][Feature] [AIRE] fix(ci): resolve 1 bug(s) from PR #126 (run 33501511407)

### DIFF
--- a/nvidia_tao_pytorch/cv/nvpanoptix3d/export/onnx_exporter.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d/export/onnx_exporter.py
@@ -19,8 +19,10 @@ from nvidia_tao_pytorch.cv.nvpanoptix3d.export.symbolic_funcs import (
     cartesian_prod_onnx,
     upsample_bicubic2d_aa,
 )
-from nvidia_tao_pytorch.cv.nvpanoptix3d.export.utils import load_2d_model
-from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.attention import Attention, MemEffAttention
+from nvidia_tao_pytorch.cv.nvpanoptix3d.export.utils import (
+    load_2d_model,
+    patch_xformers_attention_for_export,
+)
 
 
 class MaskFormerModelWrapper(nn.Module):
@@ -136,18 +138,15 @@ class ONNXExporter:
     def _patch_xformers_attention_for_export(model: nn.Module) -> None:
         """Patch xformers attention modules for ONNX export tracing.
 
-        xformers memory_efficient_attention relies on CUTLASS ops with
-        c10::SymInt arguments that the legacy JIT tracer cannot export.
-        For each MemEffAttention module in the model, this method replaces
-        ``forward`` with ``Attention.forward`` so export uses the
-        scaled-dot-product-attention path that is traceable.
+        Thin wrapper kept for backwards compatibility; the implementation now
+        lives in :func:`nvidia_tao_pytorch.cv.nvpanoptix3d.export.utils.patch_xformers_attention_for_export`
+        so the NVPanoptix3D and NVPanoptix3Dv2 exporters share a single
+        attention-patching path.
 
         Args:
             model: Model tree whose MemEffAttention modules are patched in-place.
         """
-        for module in model.modules():
-            if isinstance(module, MemEffAttention):
-                module.forward = Attention.forward.__get__(module, Attention)
+        patch_xformers_attention_for_export(model)
 
     def export_model(
         self,

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d/export/utils.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d/export/utils.py
@@ -5,6 +5,31 @@
 
 import torch
 
+from nvidia_tao_pytorch.cv.nvpanoptix3d.model.vggt.layers.attention import (
+    Attention,
+    MemEffAttention,
+)
+
+
+def patch_xformers_attention_for_export(model: torch.nn.Module) -> None:
+    """Patch xformers attention modules for ONNX export tracing.
+
+    xformers memory_efficient_attention relies on CUTLASS ops with
+    c10::SymInt arguments that the legacy JIT tracer cannot export.
+    For each MemEffAttention module in the model, this function replaces
+    ``forward`` with ``Attention.forward`` so export uses the
+    scaled-dot-product-attention path that is traceable.
+
+    This helper is shared by the NVPanoptix3D and NVPanoptix3Dv2 ONNX
+    exporters so both trace the same attention path.
+
+    Args:
+        model: Model tree whose MemEffAttention modules are patched in-place.
+    """
+    for module in model.modules():
+        if isinstance(module, MemEffAttention):
+            module.forward = Attention.forward.__get__(module, Attention)
+
 
 def load_2d_model(model: torch.nn.Module, checkpoint_path: str, device: str) -> torch.nn.Module:
     """Load a checkpoint into the model, handling common Lightning/DDP prefixes.


### PR DESCRIPTION
## Summary

Automated CI fix by **AIRE** for the Blossom-CI failure on #126.

Blossom-CI on PR #126 aborts in the `functional_tests` stage with
`hudson.AbortException: script returned exit code 2` — pytest is interrupted by **5 errors
during collection**, so no tests execute:

```
!!!!!!!!!!!!!!!!!!! Interrupted: 5 errors during collection !!!!!!!!!!!!!!!!!!!!
======================= 332 warnings, 5 errors in 42.81s =======================
```

Diagnosis identified **two** distinct bugs. One is fixed here; the other requires contributor
action and is documented below.

---

## Fixed here — `patch_xformers_attention_for_export` was never extracted

**Failure class:** `build_error` · **Confidence:** high

`nvidia_tao_pytorch/cv/nvpanoptix3d_v2/export/onnx_exporter.py:43` imports
`patch_xformers_attention_for_export` from `nvidia_tao_pytorch/cv/nvpanoptix3d/export/utils.py`,
and `tests/cv_unit_test/nvpanoptix3d_v2/test_export.py:191` asserts it is the same object as the
v2 re-export. The helper existed only as the private static method
`NVPanoptix3DExporter._patch_xformers_attention_for_export` and was never extracted, so
collecting `test_export.py` raised `ImportError`.

### Changes

- `nvidia_tao_pytorch/cv/nvpanoptix3d/export/utils.py` — add the shared
  `patch_xformers_attention_for_export` helper.
- `nvidia_tao_pytorch/cv/nvpanoptix3d/export/onnx_exporter.py` — delegate to the shared helper
  (behaviour unchanged) and drop the now-unused `Attention`/`MemEffAttention` import.

### Verification

Re-verified by Blossom-CI run
[33504855452](https://github.com/NVIDIA-TAO/tao-pytorch/actions/runs/33504855452):
`test_export.py` now progresses **past** this import and fails later at `onnx_exporter.py:47`
on a different, unrelated missing module. **This fix is confirmed working** and is worth
retaining regardless of how the remaining blocker is resolved.

---

## Known issues without a fix

### NVPanoptix3Dv2 implementation is absent from the repository

**Failure class:** `build_error` · **Confidence:** high · **Mode:** `issue_only`

The remaining 5 collection errors are all `ModuleNotFoundError`:

| Test module | Missing import |
|---|---|
| `tests/cv_unit_test/nvpanoptix3d_v2/test_config.py:12` | `nvidia_tao_pytorch.config.nvpanoptix3d_v2` |
| `tests/cv_unit_test/nvpanoptix3d_v2/test_trainer.py:15` | `nvidia_tao_pytorch.config.nvpanoptix3d_v2` |
| `tests/cv_unit_test/nvpanoptix3d_v2/test_dataloader.py:16` | `nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader` |
| `tests/cv_unit_test/nvpanoptix3d_v2/test_model.py:14` | `nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model` |
| `tests/cv_unit_test/nvpanoptix3d_v2/test_export.py:17` | `nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model` (via `export/onnx_exporter.py:47`) |

PR #126 adds the tests and the `export/` subpackage, but the model source tree those tests
exercise was never committed — the only `nvpanoptix3d_v2` paths tracked on `feature/nvp2-export`
are the three `export/` files and the five test modules. Everything else the tests import is
absent from the repository.

**AIRE deliberately did not auto-fix this.** Generating the missing modules would mean
fabricating thousands of lines of model/dataloader/loss code inferred from test assertions;
adding `importorskip`/skip markers or deleting the tests would turn CI green while silently
shipping zero coverage. Both are unacceptable, so this is handed to a human.

**Resolution:** @tcdao-nv please push the missing `nvpanoptix3d_v2` config / model / dataloader /
utils packages to `feature/nvp2-export` (or land the companion PR containing them), then re-run
`/build`.

Full breakdown in NVIDIA-TAO/tao-pytorch#127.

---

Fixes NVIDIA-TAO/tao-pytorch#127

## AIRE Self-Check
- ✅ **Scope of change:** AIRE modified only files inside this repository and pushed them as a normal git commit. ✅
- ✅ **Secret handling:** Credentials are scrubbed from all logs and never printed. ✅

Signed-off-by: svc-bcs-agent <svc-bcs-agent@nvidia.com>

<!-- AIRE-META
source_pr: 126
source_head_sha: 060125e0466ccea6ab60ef94fb72d5be3698f168
source_repo: NVIDIA-TAO/tao-pytorch
dest_repo: NVIDIA-TAO/tao-pytorch
fix_branch: fix/tao-pytorch-060125e
run_id: 33501511407
issue: 127
-->
